### PR TITLE
Use cogs:Jobs and Tasks and integrate with job-controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,21 +77,28 @@ DELETE /submission-documents/:uuid
 Deletes the data and related files on disk for a submission form based on the submitted document uuid.
 
 ### Model
+
 #### Automatic submission task
-A resource describing the status and progress of the processing of an automatic submission.
+
+A resource describing the status and operation of the subtask of processing an automatic submission job.
 
 ##### Class
-`melding:AutomaticSubmissionTask`
+
+`task:Task`
 
 ##### Properties
-The model is specified in the [README of the automatic submission service](https://github.com/lblod/automatic-submission-service#model).
+
+The model is specified in the [README of the job-controller-service](https://github.com/lblod/job-controller-service#task).
+
 ___
+
 #### Automatic submission task statuses
-Once the enrichment process starts, the status of the automatic submission task is updated to http://lblod.data.gift/automatische-melding-statuses/enriching.
 
-On successful completion, the status of the automatic submission task is updated to http://lblod.data.gift/automatische-melding-statuses/ready-for-validation.
+Once the enrichment process starts, the status of the automatic submission task is updated to http://redpencil.data.gift/id/concept/JobStatus/busy.
 
-On failure, the status is updated to http://lblod.data.gift/automatische-melding-statuses/failure.
+On successful completion, the status of the automatic submission task is updated to http://redpencil.data.gift/id/concept/JobStatus/success. The resultsContainer is then linked to the inputContainer of the task, because no file has been created or modified, only triples in the database.
+
+On failure, the status is updated to http://redpencil.data.gift/id/concept/JobStatus/failed. If possible, an error is written to the database and the error is linked to this failed task.
 ___
 #### Submitted document
 ##### Class

--- a/app.js
+++ b/app.js
@@ -53,9 +53,9 @@ app.post('/delta', async function (req, res, next) {
         
         const submissionDocument = await getSubmissionDocumentFromTask(taskUri);
         await calculateActiveForm(submissionDocument);
-        await calculateMetaSnapshot(submissionDocument);
+        const { logicalFileUri } = await calculateMetaSnapshot(submissionDocument);
 
-        await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS);
+        await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS, undefined, logicalFileUri);
       }
       catch (error) {
         const message = `Something went wrong while enriching for task ${taskUri}`;

--- a/app.js
+++ b/app.js
@@ -51,7 +51,6 @@ app.post('/delta', async function (req, res, next) {
       try {
         await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
         
-        debugger;
         const submissionDocument = await getSubmissionDocumentFromTask(taskUri);
         await calculateActiveForm(submissionDocument);
         await calculateMetaSnapshot(submissionDocument);

--- a/app.js
+++ b/app.js
@@ -1,11 +1,10 @@
 import { app, errorHandler } from 'mu';
 import bodyParser from 'body-parser';
-import flatten from 'lodash.flatten';
-import { TASK_READY_FOR_ENRICHMENT_STATUS, TASK_READY_FOR_VALIDATION_STATUS, TASK_ONGOING_STATUS, TASK_FAILURE_STATUS, updateTaskStatus } from './lib/submission-task';
+import { updateTaskStatus } from './lib/submission-task';
 import {
   getSubmissionDocument,
   deleteSubmissionDocument,
-  getSubmissionDocumentByTask,
+  getSubmissionDocumentFromTask,
   calculateMetaSnapshot,
   SENT_STATUS,
   calculateActiveForm
@@ -34,70 +33,47 @@ app.get('/', function(req, res) {
 /*
  * DELTA HANDLING
 */
-app.post('/delta', async function(req, res, next) {
-  const tasks = getAutomaticSubmissionTasks(req.body);
-  if (!tasks.length) {
-    console.log("Delta does not contain an automatic submission task with status 'ready-for-enrichment'. Nothing should happen.");
-    return res.status(204).send();
-  }
+app.post('/delta', async function (req, res, next) {
+  //We can already send a 200 back. The delta-notifier does not care about the result, as long as the request is closed.
+  res.status(200).send().end();
+  
+  try {
+    //Don't trust the delta-notifier, filter as best as possible. We just need the task that was created to get started.
+    const actualTaskUris = req.body
+      .map((changeset) => changeset.inserts)
+      .filter((inserts) => inserts.length > 0)
+      .flat()
+      .filter((insert) => insert.predicate.value === env.OPERATION_PREDICATE)
+      .filter((insert) => insert.object.value === env.ENRICH_OPERATION)
+      .map((insert) => insert.subject.value);
 
-  for (let task of tasks) {
-    try {
-      await updateTaskStatus(task, TASK_ONGOING_STATUS);
-      const submissionDocument = await getSubmissionDocumentByTask(task);
-
-      const enrich = async (submissionDocument) => {
-        try {
-          await calculateActiveForm(submissionDocument);
-          await calculateMetaSnapshot(submissionDocument);
-          await updateTaskStatus(task, TASK_READY_FOR_VALIDATION_STATUS);
-        } catch (e) {
-          await updateTaskStatus(task, TASK_FAILURE_STATUS);
-          console.log(`Something went wrong while handling deltas for automatic submission task ${task}`);
-          console.log(e);
-        }
-      };
-
-      if (submissionDocument)
-        enrich(submissionDocument); // async processing
-      else
-        console.log(`No submission document found for task ${task}`);
-    } catch (e) {
-      console.log(`Something went wrong while handling deltas for automatic submission task ${task}`);
-      console.log(e);
+    for (const taskUri of actualTaskUris) {
       try {
-        await updateTaskStatus(task, TASK_FAILURE_STATUS);
-      } catch (e) {
-        console.log(`Failed to update state of task ${task} to failure state. Is the connection to the database broken?`);
+        await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
+        
+        debugger;
+        const submissionDocument = await getSubmissionDocumentFromTask(taskUri);
+        await calculateActiveForm(submissionDocument);
+        await calculateMetaSnapshot(submissionDocument);
+
+        await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS);
       }
-      return next(e);
+      catch (error) {
+        const message = `Something went wrong while enriching for task ${taskUri}`;
+        console.error(`${message}\n`, error.message);
+        console.error(error);
+        const errorUri = await saveError({ message, detail: error.message, });
+        await updateTaskStatus(taskUri, env.TASK_FAILURE_STATUS, errorUri);
+      }
     }
   }
-
-  return res.status(200).send({ data: tasks });
+  catch (error) {
+    const message = 'The task for enriching a submission could not even be started or finished due to an unexpected problem.';
+    console.error(`${message}\n`, error.message);
+    console.error(error);
+    await saveError({ message, detail: error.message, });
+  }
 });
-
-/**
- * Returns the automatic submission tasks that are ready for enrichment
- * from the delta message. An empty array if there are none.
- *
- * @param Object delta Message as received from the delta notifier
-*/
-function getAutomaticSubmissionTasks(delta) {
-  const inserts = flatten(delta.map(changeSet => changeSet.inserts));
-  return inserts.filter(isTriggerTriple).map(t => t.subject.value);
-}
-
-/**
- * Returns whether the passed triple is a trigger for the enrichment process
- *
- * @param Object triple Triple as received from the delta notifier
-*/
-function isTriggerTriple(triple) {
-  return triple.predicate.value == 'http://www.w3.org/ns/adms#status'
-    && triple.object.value == TASK_READY_FOR_ENRICHMENT_STATUS;
-};
-
 
 /*
  * SUBMISSION DOCUMENT ENDPOINTS

--- a/app.js
+++ b/app.js
@@ -10,6 +10,8 @@ import {
   SENT_STATUS,
   calculateActiveForm
 } from './lib/submission-document';
+import * as env from './env.js';
+import { saveError } from './lib/utils.js';
 
 
 function setup() {

--- a/env.js
+++ b/env.js
@@ -7,7 +7,7 @@ export const TASK_ONGOING_STATUS = 'http://redpencil.data.gift/id/concept/JobSta
 export const TASK_SUCCESS_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/success';
 export const TASK_FAILURE_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/failed';
 
-const PREFIX_TABLE = {
+export const PREFIX_TABLE = {
   meb:          'http://rdf.myexperiment.org/ontologies/base/',
   xsd:          'http://www.w3.org/2001/XMLSchema#',
   pav:          'http://purl.org/pav/',
@@ -32,6 +32,7 @@ const PREFIX_TABLE = {
   wotSec:       'https://www.w3.org/2019/wot/security#',
   task:         'http://redpencil.data.gift/vocabularies/tasks/',
   asj:          'http://data.lblod.info/id/automatic-submission-job/',
+  dbpedia:      'http://dbpedia.org/ontology/',
 };
 
 export const PREFIXES = (() => {

--- a/env.js
+++ b/env.js
@@ -1,0 +1,50 @@
+export const CREATOR = 'http://lblod.data.gift/services/enrich-submission-service';
+
+export const OPERATION_PREDICATE = 'http://redpencil.data.gift/vocabularies/tasks/operation';
+export const ENRICH_OPERATION = 'http://lblod.data.gift/id/jobs/concept/TaskOperation/enrich';
+
+export const TASK_ONGOING_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/busy';
+export const TASK_SUCCESS_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/success';
+export const TASK_FAILURE_STATUS = 'http://redpencil.data.gift/id/concept/JobStatus/failed';
+
+const PREFIX_TABLE = {
+  meb:          'http://rdf.myexperiment.org/ontologies/base/',
+  xsd:          'http://www.w3.org/2001/XMLSchema#',
+  pav:          'http://purl.org/pav/',
+  dct:          'http://purl.org/dc/terms/',
+  melding:      'http://lblod.data.gift/vocabularies/automatische-melding/',
+  lblodBesluit: 'http://lblod.data.gift/vocabularies/besluit/',
+  adms:         'http://www.w3.org/ns/adms#',
+  muAccount:    'http://mu.semte.ch/vocabularies/account/',
+  eli:          'http://data.europa.eu/eli/ontology#',
+  org:          'http://www.w3.org/ns/org#',
+  elod:         'http://linkedeconomy.org/ontology#',
+  nie:          'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#',
+  prov:         'http://www.w3.org/ns/prov#',
+  mu:           'http://mu.semte.ch/vocabularies/core/',
+  foaf:         'http://xmlns.com/foaf/0.1/',
+  nfo:          'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#',
+  ext:          'http://mu.semte.ch/vocabularies/ext/',
+  http:         'http://www.w3.org/2011/http#',
+  rpioHttp:     'http://redpencil.data.gift/vocabularies/http/',
+  dgftSec:      'http://lblod.data.gift/vocabularies/security/',
+  dgftOauth:    'http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/',
+  wotSec:       'https://www.w3.org/2019/wot/security#',
+  task:         'http://redpencil.data.gift/vocabularies/tasks/',
+  asj:          'http://data.lblod.info/id/automatic-submission-job/',
+};
+
+export const PREFIXES = (() => {
+  const all = [];
+  for (const key in PREFIX_TABLE)
+    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
+  return all.join('\n');
+})();
+
+export function getPrefixes(collOfPrefixes) {
+  const all = [];
+  for (const key of collOfPrefixes)
+    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
+  return all.join('\n');
+}
+

--- a/env.js
+++ b/env.js
@@ -41,11 +41,3 @@ export const PREFIXES = (() => {
     all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
   return all.join('\n');
 })();
-
-export function getPrefixes(collOfPrefixes) {
-  const all = [];
-  for (const key of collOfPrefixes)
-    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
-  return all.join('\n');
-}
-

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -1,5 +1,5 @@
 import { sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime, sparqlEscapeInt, uuid, update } from 'mu';
-import { updateSudo } from '@lblod/mu-auth-sudo';
+import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import fs from 'fs-extra';
 import * as env from '../env.js';
 
@@ -86,11 +86,12 @@ async function insertTtlFile(submissionDocument, content) {
 }
 
 async function updateTtlFile(submissionDocument, logicalFileUri, content) {
-  const response = await query(`
+  const response = await querySudo(`
+    ${env.getPrefixes(['nie', 'ext'])}
     SELECT ?physicalUri WHERE {
       GRAPH ?g {
         ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
-        ?physicalUri nie:dataSource ${sparqlEscapeUri(logicalFile)} .
+        ?physicalUri nie:dataSource ${sparqlEscapeUri(logicalFileUri)} .
       }
     }
   `);

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -10,12 +10,27 @@ const PUBLIC_FILES_GRAPH = process.env.PUBLIC_FILES_GRAPH || 'http://mu.semte.ch
  *
  * @param string file URI of the file to get the content for
 */
-async function getFileContent(file) {
-  console.log(`Getting contents of file ${file}`);
-  const path = file.replace('share://', '/share/');
+async function getFileContent(logicalFileUri) {
+  const response = await querySudo(`
+    ${env.PREFIXES}
+    SELECT ?physicalFile WHERE {
+      ?physicalFile nie:dataSource ${sparqlEscapeUri(logicalFileUri)} .
+    }
+  `);
+  const physicalFileUri = response.results.bindings[0]?.physicalFile?.value;
+
+  console.log(`Getting contents of file ${physicalFileUri}`);
+  const path = physicalFileUri.replace('share://', '/share/');
   const content = await fs.readFile(path, 'utf8');
   return content;
 };
+
+async function getFileContentPhysical(physicalFileUri) {
+  console.log(`Getting contents of file ${physicalFileUri}`);
+  const path = physicalFileUri.replace('share://', '/share/');
+  const content = await fs.readFile(path, 'utf8');
+  return content;
+}
 
 /**
  * Write the given TTL content to a file and relates it to the given submitted document
@@ -187,6 +202,7 @@ async function deleteTtlFile(logicalFile) {
 export {
   PUBLIC_FILES_GRAPH,
   getFileContent,
+  getFileContentPhysical,
   insertTtlFile,
   updateTtlFile,
   deleteTtlFile

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -1,6 +1,7 @@
 import { sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime, sparqlEscapeInt, uuid, update } from 'mu';
 import { updateSudo } from '@lblod/mu-auth-sudo';
 import fs from 'fs-extra';
+import * as env from '../env.js';
 
 const PUBLIC_FILES_GRAPH = process.env.PUBLIC_FILES_GRAPH || 'http://mu.semte.ch/graphs/public';
 
@@ -22,16 +23,18 @@ async function getFileContent(file) {
  * @param string ttl Turtle to write to the file
 */
 async function insertTtlFile(submissionDocument, content) {
-  const id = uuid();
-  const filename = `${id}.ttl`;
+  const logicalId = uuid();
+  const physicalId = uuid();
+  const filename = `${physicalId}.ttl`;
   const path = `/share/submissions/${filename}`;
-  const uri = path.replace('/share/', 'share://');
-  const now = new Date();
+  const physicalUri = path.replace('/share/', 'share://');
+  const logicalUri = env.PREFIX_TABLE.asj.concat(logicalId);
+  const nowSparql = sparqlEscapeDateTime(new Date());
 
   try {
     await fs.writeFile(path, content, 'utf-8');
   } catch (e) {
-    console.log(`Failed to write TTL to file <${uri}>.`);
+    console.log(`Failed to write TTL to file <${path}>.`);
     throw e;
   }
 
@@ -41,50 +44,64 @@ async function insertTtlFile(submissionDocument, content) {
 
     //Sudo required because may be called both from automatic-submission or user
     await updateSudo(`
-      PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-      PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX dct: <http://purl.org/dc/terms/>
-      PREFIX dbpedia: <http://dbpedia.org/ontology/>
-      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-
+      ${env.PREFIXES}
       INSERT {
         GRAPH ?g {
-          ${sparqlEscapeUri(uri)} a nfo:FileDataObject ;
-                                  mu:uuid ${sparqlEscapeString(id)};
-                                  nfo:fileName ${sparqlEscapeString(filename)} ;
-                                  dct:creator <http://lblod.data.gift/services/enrich-submission-service>;
-                                  dct:created ${sparqlEscapeDateTime(now)};
-                                  dct:modified ${sparqlEscapeDateTime(now)};
-                                  dct:format "text/turtle";
-                                  nfo:fileSize ${sparqlEscapeInt(fileSize)};
-                                  dbpedia:fileExtension "ttl" .
+          ${sparqlEscapeUri(physicalUri)}
+            a nfo:FileDataObject ;
+            mu:uuid ${sparqlEscapeString(physicalId)} ;
+            nie:dataSource asj:${logicalId} ;
+            nfo:fileName ${sparqlEscapeString(filename)} ;
+            dct:creator ${sparqlEscapeUri(env.CREATOR)} ;
+            dct:created ${nowSparql} ;
+            dct:modified ${nowSparql} ;
+            dct:format "text/turtle" ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
+            dbpedia:fileExtension "ttl" .
+
+          asj:${logicalId}
+            a nfo:FileDataObject;
+            mu:uuid ${sparqlEscapeString(logicalId)} ;
+            nfo:fileName ${sparqlEscapeString(filename)} ;
+            dct:creator ${sparqlEscapeUri(env.CREATOR)} ;
+            dct:created ${nowSparql} ;
+            dct:modified ${nowSparql} ;
+            dct:format "text/turtle" ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} ;
+            dbpedia:fileExtension "ttl" . 
         }
       }
       WHERE {
         GRAPH ?g {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
-      }
-`);
+      }`);
 
   } catch (e) {
-    console.log(`Failed to write TTL resource <${uri}> to triplestore.`);
+    console.log(`Failed to write TTL resource <${logicalUri}> to triplestore.`);
     throw e;
   }
 
-  return uri;
+  return logicalUri;
 }
 
-async function updateTtlFile(submissionDocument, uri, content) {
-  const path = uri.replace('share://', '/share/');
+async function updateTtlFile(submissionDocument, logicalFileUri, content) {
+  const response = await query(`
+    SELECT ?physicalUri WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
+        ?physicalUri nie:dataSource ${sparqlEscapeUri(logicalFile)} .
+      }
+    }
+  `);
+  const physicalUri = response.results.bindings[0].physicalUri.value;
+  const path = physicalUri.replace('share://', '/share/');
   const now = new Date();
 
   try {
     await fs.writeFile(path, content, 'utf-8');
   } catch (e) {
-    console.log(`Failed to write TTL to file <${uri}>.`);
+    console.log(`Failed to write TTL to file <${path}>.`);
     throw e;
   }
 
@@ -95,26 +112,27 @@ async function updateTtlFile(submissionDocument, uri, content) {
     //Sudo required because may be called both from automatic-submission or user
     await updateSudo(`
       PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-      PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX dct: <http://purl.org/dc/terms/>
-      PREFIX dbpedia: <http://dbpedia.org/ontology/>
-      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
-      DELETE WHERE {
+      DELETE {
         GRAPH ?g {
-          ${sparqlEscapeUri(uri)} dct:modified ?modified ;
-                                  nfo:fileSize ?fileSize .
+          ${sparqlEscapeUri(physicalUri)}
+            dct:modified ?modified ;
+            nfo:fileSize ?fileSize .
+          ${sparqlEscapeUri(logicalFileUri)}
+            dct:modified ?modified ;
+            nfo:fileSize ?fileSize .
         }
       }
-
-      ;
-
       INSERT {
         GRAPH ?g {
-          ${sparqlEscapeUri(uri)} dct:modified ${sparqlEscapeDateTime(now)} ;
-                                  nfo:fileSize ${sparqlEscapeInt(fileSize)} .
+          ${sparqlEscapeUri(physicalUri)}
+            dct:modified ${sparqlEscapeDateTime(now)} ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} .
+          ${sparqlEscapeUri(logicalFileUri)}
+            dct:modified ${sparqlEscapeDateTime(now)} ;
+            nfo:fileSize ${sparqlEscapeInt(fileSize)} .
         }
       }
       WHERE {
@@ -122,10 +140,10 @@ async function updateTtlFile(submissionDocument, uri, content) {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
       }
-`);
+  `);
 
   } catch (e) {
-    console.log(`Failed to update TTL resource <${uri}> in triplestore.`);
+    console.log(`Failed to update TTL resource <${logicalFileUri}> in triplestore.`);
     throw e;
   }
 }
@@ -133,32 +151,34 @@ async function updateTtlFile(submissionDocument, uri, content) {
 /**
  * Deletes a ttl file in the triplestore and on disk
 */
-async function deleteTtlFile(uri) {
-  const path = uri.replace('share://', '/share/');
+async function deleteTtlFile(logicalFile) {
+  const response = await query(`
+    SELECT ?physicalUri WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
+        ?physicalUri nie:dataSource ${sparqlEscapeUri(logicalFile)} .
+      }
+    }
+  `);
+  const physicalUri = response.results.bindings[0].physicalUri.value;
+  const path = physicalUri.replace('share://', '/share/');
 
   try {
     await fs.unlink(path);
   } catch (e) {
-    console.log(`Failed to delete TTL file <${uri}> on disk: \n ${e}`);
+    console.log(`Failed to delete TTL file <${physicalUri}> on disk: \n ${e}`);
     throw e;
   }
 
   try {
     await update(`
-      PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-      PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX dct: <http://purl.org/dc/terms/>
-      PREFIX dbpedia: <http://dbpedia.org/ontology/>
-      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-
       DELETE WHERE {
-          ${sparqlEscapeUri(uri)} ?p ?o .
+          ${sparqlEscapeUri(physicalUri)} ?p1 ?o1 .
+          ${sparqlEscapeUri(logicalUri)} ?p2 ?o2 .
       }
     `);
-
   } catch (e) {
-    console.log(`Failed to delete TTL resource <${uri}> in triplestore: \n ${e}`);
+    console.log(`Failed to delete TTL resource <${logicalFile}> in triplestore: \n ${e}`);
     throw e;
   }
 }

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -102,7 +102,7 @@ async function insertTtlFile(submissionDocument, content) {
 
 async function updateTtlFile(submissionDocument, logicalFileUri, content) {
   const response = await querySudo(`
-    ${env.getPrefixes(['nie', 'ext'])}
+    ${env.PREFIXES}
     SELECT ?physicalUri WHERE {
       GRAPH ?g {
         ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -115,29 +115,25 @@ export async function calculateActiveForm(submissionDocument, formFile = ACTIVE_
     return await getFileContent(formFile);
 }
 
-async function getSubmissionDocumentByTask(taskUri) {
-  const result = await querySudo(`
-    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
-    PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
-    PREFIX adms: <http://www.w3.org/ns/adms#>
-    PREFIX dct: <http://purl.org/dc/terms/>
-
+export async function getSubmissionDocumentFromTask(taskUri) {
+  const response = await querySudo(`
+    ${env.getPrefixes(['task', 'dct', 'prov'])}
     SELECT ?submissionDocument
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} prov:generated ?submission ;
-           a melding:AutomaticSubmissionTask .
+        ${sparqlEscapeUri(taskUri)}
+          a task:Task ;
+          dct:isPartOf ?job .
+        ?job prov:generated ?submission .
         ?submission dct:subject ?submissionDocument .
       }
     } LIMIT 1
   `);
 
-  if (result.results.bindings.length) {
-    const binding = result.results.bindings[0];
-    return binding['submissionDocument'].value;
-  } else {
-    return null;
+  const bindings = response?.results?.bindings;
+  if (bindings && bindings.length > 0) {
+    const binding = bindings[0];
+    return binding.submissionDocument.value;
   }
 }
 

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -43,7 +43,7 @@ export async function getSubmissionDocument(uuid) {
       console.log('Form is in concept status. Getting harvested data and additions/removals.');
       const formFile = await getFormFile(submissionDocument);
       const form = await calculateActiveForm(submissionDocument, formFile);
-      const meta = await calculateMetaSnapshot(submissionDocument);
+      const { meta } = await calculateMetaSnapshot(submissionDocument);
       const source = await getHarvestedData(submissionDocument);
       const additions = await getAdditions(submissionDocument);
       const removals = await getRemovals(submissionDocument);
@@ -101,8 +101,8 @@ export async function deleteSubmissionDocument(uuid) {
 */
 export async function calculateMetaSnapshot(submissionDocument) {
   const content = await enrich(submissionDocument);
-  await saveMeta(submissionDocument, content);
-  return content;
+  const logicalFileUri = await saveMeta(submissionDocument, content);
+  return { meta: content, logicalFileUri };
 }
 
 /**
@@ -218,22 +218,19 @@ async function getHarvestedData(submissionDocument) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT DISTINCT ?ttlFile
+    SELECT DISTINCT ?physicalFile
     WHERE {
       GRAPH ?g {
-        ?submission dct:subject ${sparqlEscapeUri(submissionDocument)} ;
-                    nie:hasPart ?remoteFile .
-        ?localHtmlDownload nie:dataSource ?remoteFile .
-        ?ttlFile nie:dataSource ?localHtmlDownload .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
+        ?logicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
+        ?physicalFile nie:dataSource ?logicalFile .
       }
     }
   `);
 
   if (result.results.bindings.length) {
-    const file = result.results.bindings[0]['ttlFile'].value;
+    const file = result.results.bindings[0]['physicalFile'].value;
     return await getFileContent(file);
-  } else {
-    return null;
   }
 }
 
@@ -360,25 +357,25 @@ async function savePart(submissionDocument, content, fileType) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT ?file
+    SELECT ?logicalFile
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?file .
-        ?file dct:type ${sparqlEscapeUri(fileType)} .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
+        ?logicalFile dct:type ${sparqlEscapeUri(fileType)} .
       }
     }
   `);
 
   if (!result.results.bindings.length) {
-    const file = await insertTtlFile(submissionDocument, content);
+    const logicalFileUri = await insertTtlFile(submissionDocument, content);
     await updateSudo(`
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
       INSERT {
         GRAPH ?g {
-          ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(file)} .
-          ${sparqlEscapeUri(file)} dct:type ${sparqlEscapeUri(fileType)} .
+          ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(logicalFileUri)} .
+          ${sparqlEscapeUri(logicalFileUri)} dct:type ${sparqlEscapeUri(fileType)} .
         }
       } WHERE {
         GRAPH ?g {
@@ -386,11 +383,11 @@ async function savePart(submissionDocument, content, fileType) {
         }
       }
     `);
-    return file;
+    return logicalFileUri;
   } else {
-    const file = result.results.bindings[0]['file'].value;
-    await updateTtlFile(submissionDocument, file, content);
-    return file;
+    const logicalFile = result.results.bindings[0]['logicalFile'].value;
+    await updateTtlFile(submissionDocument, logicalFile, content);
+    return logicalFile;
   }
 }
 

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -1,7 +1,7 @@
 import { query, sparqlEscapeString, sparqlEscapeUri, uuid } from 'mu';
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import enrich from './enricher';
-import { PUBLIC_FILES_GRAPH, getFileContent, insertTtlFile, updateTtlFile, deleteTtlFile } from './file-helpers';
+import { PUBLIC_FILES_GRAPH, getFileContent, getFileContentPhysical, insertTtlFile, updateTtlFile, deleteTtlFile } from './file-helpers';
 import fs from 'fs-extra';
 import * as env from '../env.js';
 
@@ -112,7 +112,7 @@ export async function calculateMetaSnapshot(submissionDocument) {
  */
 export async function calculateActiveForm(submissionDocument, formFile = ACTIVE_FORM_FILE) {
     await saveForm(submissionDocument, formFile);
-    return await getFileContent(formFile);
+    return await getFileContentPhysical(formFile);
 }
 
 export async function getSubmissionDocumentFromTask(taskUri) {
@@ -218,18 +218,17 @@ async function getHarvestedData(submissionDocument) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT DISTINCT ?physicalFile
+    SELECT DISTINCT ?logicalFile
     WHERE {
       GRAPH ?g {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
         ?logicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
-        ?physicalFile nie:dataSource ?logicalFile .
       }
     }
   `);
 
   if (result.results.bindings.length) {
-    const file = result.results.bindings[0]['physicalFile'].value;
+    const file = result.results.bindings[0]['logicalFile'].value;
     return await getFileContent(file);
   }
 }
@@ -263,7 +262,7 @@ function getRemovals(submissionDocument) {
  * @return {string} TTL with the form used to submit the document
 */
 function getSubmittedForm(submissionDocument) {
-  return getPart(submissionDocument, FORM_FILE_TYPE);
+  return getPartWithoutLogical(submissionDocument, FORM_FILE_TYPE);
 }
 
 /**
@@ -297,11 +296,11 @@ async function getSubmittedFormData(submissionDocument) {
 */
 async function getPart(submissionDocument, fileType) {
   const file = await getFileResource(submissionDocument, fileType);
-  if (file) {
-    return await getFileContent(file);
-  } else {
-    return null;
-  }
+  if (file) return await getFileContent(file);
+}
+async function getPartWithoutLogical(submissionDocument, fileType) {
+  const file = await getFileResource(submissionDocument, fileType);
+  if (file) return await getFileContentPhysical(file);
 }
 
 /**
@@ -317,20 +316,19 @@ async function getFileResource(submissionDocument, fileType) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT DISTINCT ?file
+    SELECT DISTINCT ?logicalFile
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?file .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
       }
-      ?file dct:type ${sparqlEscapeUri(fileType)} .
+      ?logicalFile dct:type ${sparqlEscapeUri(fileType)} .
     }
   `);
 
   if (result.results.bindings.length) {
-    return result.results.bindings[0]['file'].value;
+    return result.results.bindings[0]['logicalFile'].value;
   } else {
     console.log(`Part of type ${fileType} for submission document ${submissionDocument} not found`);
-    return null;
   }
 }
 

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -117,7 +117,7 @@ export async function calculateActiveForm(submissionDocument, formFile = ACTIVE_
 
 export async function getSubmissionDocumentFromTask(taskUri) {
   const response = await querySudo(`
-    ${env.getPrefixes(['task', 'dct', 'prov'])}
+    ${env.PREFIXES}
     SELECT ?submissionDocument
     WHERE {
       GRAPH ?g {

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -3,6 +3,7 @@ import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import enrich from './enricher';
 import { PUBLIC_FILES_GRAPH, getFileContent, insertTtlFile, updateTtlFile, deleteTtlFile } from './file-helpers';
 import fs from 'fs-extra';
+import * as env from '../env.js';
 
 const CONCEPT_STATUS = 'http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd';
 const SUBMITABLE_STATUS = 'http://lblod.data.gift/concepts/f6330856-e261-430f-b949-8e510d20d0ff';
@@ -33,7 +34,7 @@ export default class SubmissionDocument {
  * In case the submission is still in concept status, the harvested data (if any), additions and removals are returned.
  * In case the submission is already submitted, the submitted data is returned.
 */
-async function getSubmissionDocument(uuid) {
+export async function getSubmissionDocument(uuid) {
   const { submissionDocument, status } = await getSubmissionDocumentById(uuid);
 
   if (submissionDocument) {
@@ -65,7 +66,7 @@ async function getSubmissionDocument(uuid) {
  *
  * @return {Object} Object containing the submission document URI and submission status
 */
-async function deleteSubmissionDocument(uuid) {
+export async function deleteSubmissionDocument(uuid) {
   const { submissionDocument, status } = await getSubmissionDocumentById(uuid);
 
   if (submissionDocument) {
@@ -98,7 +99,7 @@ async function deleteSubmissionDocument(uuid) {
  * When the submission is submitted, the metadata snapshot is frozen and can no longer
  * be updated.
 */
-async function calculateMetaSnapshot(submissionDocument) {
+export async function calculateMetaSnapshot(submissionDocument) {
   const content = await enrich(submissionDocument);
   await saveMeta(submissionDocument, content);
   return content;
@@ -109,7 +110,7 @@ async function calculateMetaSnapshot(submissionDocument) {
  *
  * @return {string} TTL with the current form
  */
-async function calculateActiveForm(submissionDocument, formFile = ACTIVE_FORM_FILE) {
+export async function calculateActiveForm(submissionDocument, formFile = ACTIVE_FORM_FILE) {
     await saveForm(submissionDocument, formFile);
     return await getFileContent(formFile);
 }
@@ -139,15 +140,6 @@ async function getSubmissionDocumentByTask(taskUri) {
     return null;
   }
 }
-
-export {
-  getSubmissionDocument,
-  deleteSubmissionDocument,
-  calculateActiveForm,
-  calculateMetaSnapshot,
-  getSubmissionDocumentByTask
-}
-
 
 /*
  * Private

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -3,40 +3,44 @@ import * as mas from '@lblod/mu-auth-sudo';
 import * as env from '../env.js';
 
 /**
- * Updates the state of the given task to the specified status
+ * Updates the state of the given task to the specified status with potential error message or resultcontainer file
  *
  * @param string taskUri URI of the task
  * @param string status URI of the new status
+ * @param string or undefined URI of the error that needs to be attached
 */
-async function updateTaskStatus(taskUri, status) {
-  const q = `
-    PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
-    PREFIX adms: <http://www.w3.org/ns/adms#>
+export async function updateTaskStatus(taskUri, status, errorUri) {
+  const taskUriSparql = mu.sparqlEscapeUri(taskUri);
+  const nowSparql = mu.sparqlEscapeDateTime((new Date()).toISOString());
+  const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
 
+  const statusUpdateQuery = `
+    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu'])}
     DELETE {
       GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} adms:status ?status .
-      }
-    } WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} adms:status ?status .
+        ${taskUriSparql}
+          adms:status ?oldStatus ;
+          dct:modified ?oldModified .
       }
     }
-
-    ;
-
     INSERT {
       GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} adms:status ${sparqlEscapeUri(status)} .
-      }
-    } WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(taskUri)} a melding:AutomaticSubmissionTask .
+        ${taskUriSparql}
+          adms:status ${mu.sparqlEscapeUri(status)} ;
+          ${hasError ? `task:error ${mu.sparqlEscapeUri(errorUri)} ;` : ''}
+          ${(status === env.TASK_SUCCESS_STATUS) ? `task:resultContainer ?inputContainer ;` : ''}
+          dct:modified ${nowSparql} .
       }
     }
-
+    WHERE {
+      GRAPH ?g {
+        ${taskUriSparql}
+          adms:status ?oldStatus ;
+          ${(status === env.TASK_SUCCESS_STATUS) ? `task:inputContainer ?inputContainer ;` : ''}
+          dct:modified ?oldModified .
+      }
+    }
   `;
-
   await mas.updateSudo(statusUpdateQuery);
 }
 

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -28,7 +28,7 @@ export async function updateTaskStatus(taskUri, status, errorUri, logicalFileUri
 
 
   const statusUpdateQuery = `
-    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu'])}
+    ${env.PREFIXES}
     DELETE {
       GRAPH ?g {
         ${taskUriSparql}

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -1,11 +1,6 @@
-import { sparqlEscapeUri } from 'mu';
-import { updateSudo as update } from '@lblod/mu-auth-sudo';
-
-const TASK_READY_FOR_ENRICHMENT_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/ready-for-enrichment';
-const TASK_READY_FOR_VALIDATION_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/ready-for-validation';
-const TASK_ONGOING_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/enriching';
-const TASK_SUCCESS_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/success';
-const TASK_FAILURE_STATUS = 'http://lblod.data.gift/automatische-melding-statuses/failure';
+import * as mu from 'mu';
+import * as mas from '@lblod/mu-auth-sudo';
+import * as env from '../env.js';
 
 /**
  * Updates the state of the given task to the specified status
@@ -42,14 +37,6 @@ async function updateTaskStatus(taskUri, status) {
 
   `;
 
-  await update(q);
+  await mas.updateSudo(statusUpdateQuery);
 }
 
-export {
-  TASK_READY_FOR_ENRICHMENT_STATUS,
-  TASK_READY_FOR_VALIDATION_STATUS,
-  TASK_ONGOING_STATUS,
-  TASK_SUCCESS_STATUS,
-  TASK_FAILURE_STATUS,
-  updateTaskStatus
-}

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -9,10 +9,23 @@ import * as env from '../env.js';
  * @param string status URI of the new status
  * @param string or undefined URI of the error that needs to be attached
 */
-export async function updateTaskStatus(taskUri, status, errorUri) {
+export async function updateTaskStatus(taskUri, status, errorUri, logicalFileUri) {
   const taskUriSparql = mu.sparqlEscapeUri(taskUri);
   const nowSparql = mu.sparqlEscapeDateTime((new Date()).toISOString());
   const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
+
+  let resultContainerTriples = '';
+  let resultContainerUuid = '';
+  if (logicalFileUri) {
+    resultContainerUuid = mu.uuid();
+    resultContainerTriples = `
+      asj:${resultContainerUuid}
+        a nfo:DataContainer ;
+        mu:uuid ${mu.sparqlEscapeString(resultContainerUuid)} ;
+        task:hasFile ${mu.sparqlEscapeUri(logicalFileUri)} .
+    `;
+  }
+
 
   const statusUpdateQuery = `
     ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu'])}
@@ -28,15 +41,16 @@ export async function updateTaskStatus(taskUri, status, errorUri) {
         ${taskUriSparql}
           adms:status ${mu.sparqlEscapeUri(status)} ;
           ${hasError ? `task:error ${mu.sparqlEscapeUri(errorUri)} ;` : ''}
-          ${(status === env.TASK_SUCCESS_STATUS) ? `task:resultsContainer ?inputContainer ;` : ''}
+          ${resultContainerUuid ? `task:resultsContainer asj:${resultContainerUuid} ;` : ''}
           dct:modified ${nowSparql} .
+
+        ${resultContainerTriples}
       }
     }
     WHERE {
       GRAPH ?g {
         ${taskUriSparql}
           adms:status ?oldStatus ;
-          ${(status === env.TASK_SUCCESS_STATUS) ? `task:inputContainer ?inputContainer ;` : ''}
           dct:modified ?oldModified .
       }
     }

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -28,7 +28,7 @@ export async function updateTaskStatus(taskUri, status, errorUri) {
         ${taskUriSparql}
           adms:status ${mu.sparqlEscapeUri(status)} ;
           ${hasError ? `task:error ${mu.sparqlEscapeUri(errorUri)} ;` : ''}
-          ${(status === env.TASK_SUCCESS_STATUS) ? `task:resultContainer ?inputContainer ;` : ''}
+          ${(status === env.TASK_SUCCESS_STATUS) ? `task:resultsContainer ?inputContainer ;` : ''}
           dct:modified ${nowSparql} .
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,38 @@
+import * as mas from '@lblod/mu-auth-sudo';
+import * as mu from 'mu';
+import * as env from '../env.js';
+
+export async function saveError({message, detail, reference}) {
+  if (!message)
+    throw 'Error needs a message describing what went wrong.';
+  const id = mu.uuid();
+  const uri = `http://data.lblod.info/errors/${id}`;
+  const q = `
+    PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+    PREFIX oslc: <http://open-services.net/ns/core#>
+    PREFIX dct:  <http://purl.org/dc/terms/>
+    PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+    INSERT DATA {
+      GRAPH <http://mu.semte.ch/graphs/error> {
+        ${mu.sparqlEscapeUri(uri)}
+          a oslc:Error ;
+          mu:uuid ${mu.sparqlEscapeString(id)} ;
+          dct:subject ${mu.sparqlEscapeString('Automatic Submission Service')} ;
+          oslc:message ${mu.sparqlEscapeString(message)} ;
+          dct:created ${mu.sparqlEscapeDateTime(new Date().toISOString())} ;
+          ${reference ? `dct:references ${mu.sparqlEscapeUri(reference)} ;` : ''}
+          ${detail ? `oslc:largePreview ${mu.sparqlEscapeString(detail)} ;` : ''}
+          dct:creator ${mu.sparqlEscapeUri(env.CREATOR)} .
+      }
+    }
+   `;
+  try {
+    await mas.updateSudo(q);
+    return uri;
+  }
+  catch (e) {
+    console.warn(`[WARN] Something went wrong while trying to store an error.\nMessage: ${e}\nQuery: ${q}`);
+  }
+}
+


### PR DESCRIPTION
This PR makes this service integrate with the job-controller-service. It listens for scheduled tasks with operation "enrich" and starts the enrichment process from the data in the inputContainer of the task. Some function have been removed or rewritten because of this. When the task is finished, its status is set to "success" and the resultsContainer will point to the inputContainer, because no file has been created or modified, only triples in the database. Ideally, we should have a resultsContainer that can point to individuals in the data as well.

Some constants have also been moved to a separate file and some imports are now done differently.