### PR TITLE
Reverting to previous file linking

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,9 +53,9 @@ app.post('/delta', async function (req, res, next) {
         
         const submissionDocument = await getSubmissionDocumentFromTask(taskUri);
         await calculateActiveForm(submissionDocument);
-        const { logicalFileUri } = await calculateMetaSnapshot(submissionDocument);
+        const { logicalFile } = await calculateMetaSnapshot(submissionDocument);
 
-        await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS, undefined, logicalFileUri);
+        await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS, undefined, logicalFile);
       }
       catch (error) {
         const message = `Something went wrong while enriching for task ${taskUri}`;

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -97,7 +97,7 @@ async function insertTtlFile(submissionDocument, content) {
     throw e;
   }
 
-  return logicalUri;
+  return { logicalFile: logicalUri, physicalFile: physicalUri };
 }
 
 async function updateTtlFile(submissionDocument, logicalFileUri, content) {

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -217,18 +217,19 @@ async function getHarvestedData(submissionDocument) {
   const result = await query(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-
-    SELECT DISTINCT ?physicalFile
+    SELECT DISTINCT ?ttlFile
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
-        ?physicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
+        ?submission dct:subject ${sparqlEscapeUri(submissionDocument)} ;
+                    nie:hasPart ?remoteFile .
+        ?localHtmlDownload nie:dataSource ?remoteFile;
+           a  <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#LocalFileDataObject>.
+        ?ttlFile nie:dataSource ?localHtmlDownload .
       }
     }
   `);
-
   if (result.results.bindings.length) {
-    const file = result.results.bindings[0]['physicalFile'].value;
+    const file = result.results.bindings[0]['ttlFile'].value;
     return await getFileContentPhysical(file);
   }
 }

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -388,7 +388,7 @@ async function savePart(submissionDocument, content, fileType) {
     return { logicalFile, physicalFile };
   } else {
     const logicalFile = result.results.bindings[0]['logicalFile'].value;
-    const physicalFile = results.results.bindings[0]['physicalFile'].value;
+    const physicalFile = result.results.bindings[0]['physicalFile'].value;
     await updateTtlFile(submissionDocument, logicalFile, content);
     return { logicalFile, physicalFile };
   }

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -329,6 +329,7 @@ async function getFileResource(submissionDocument, fileType) {
     };
   } else {
     console.log(`Part of type ${fileType} for submission document ${submissionDocument} not found`);
+    return { logicalFile: undefined, physicalFile: undefined };
   }
 }
 

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -74,10 +74,10 @@ export async function deleteSubmissionDocument(uuid) {
     if (status == SENT_STATUS) {
       console.log(`Form with uuid ${uuid} is in sent status and can\'t be deleted.`);
     } else {
-      const additionsFile = await getFileResource(submissionDocument, ADDITIONS_FILE_TYPE);
-      const removalsFile = await getFileResource(submissionDocument, REMOVALS_FILE_TYPE);
-      const metaFile = await getFileResource(submissionDocument, META_FILE_TYPE);
-      const sourceFile = await getFileResource(submissionDocument, FORM_DATA_FILE_TYPE);
+      const additionsFile = (await getFileResource(submissionDocument, ADDITIONS_FILE_TYPE)).logicalFile;
+      const removalsFile = (await getFileResource(submissionDocument, REMOVALS_FILE_TYPE)).logicalFile;
+      const metaFile = (await getFileResource(submissionDocument, META_FILE_TYPE)).logicalFile;
+      const sourceFile = (await getFileResource(submissionDocument, FORM_DATA_FILE_TYPE)).logicalFile;
 
       if (additionsFile) deleteTtlFile(additionsFile);
       if (removalsFile) deleteTtlFile(removalsFile);
@@ -101,8 +101,8 @@ export async function deleteSubmissionDocument(uuid) {
 */
 export async function calculateMetaSnapshot(submissionDocument) {
   const content = await enrich(submissionDocument);
-  const logicalFileUri = await saveMeta(submissionDocument, content);
-  return { meta: content, logicalFileUri };
+  const { logicalFile, physicalFile } = await saveMeta(submissionDocument, content);
+  return { meta: content, logicalFile, physicalFile };
 }
 
 /**
@@ -218,18 +218,18 @@ async function getHarvestedData(submissionDocument) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT DISTINCT ?logicalFile
+    SELECT DISTINCT ?physicalFile
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
-        ?logicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
+        ?physicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
       }
     }
   `);
 
   if (result.results.bindings.length) {
-    const file = result.results.bindings[0]['logicalFile'].value;
-    return await getFileContent(file);
+    const file = result.results.bindings[0]['physicalFile'].value;
+    return await getFileContentPhysical(file);
   }
 }
 
@@ -262,7 +262,7 @@ function getRemovals(submissionDocument) {
  * @return {string} TTL with the form used to submit the document
 */
 function getSubmittedForm(submissionDocument) {
-  return getPartWithoutLogical(submissionDocument, FORM_FILE_TYPE);
+  return getPart(submissionDocument, FORM_FILE_TYPE);
 }
 
 /**
@@ -295,12 +295,8 @@ async function getSubmittedFormData(submissionDocument) {
  * @return {string} Content of the related file
 */
 async function getPart(submissionDocument, fileType) {
-  const file = await getFileResource(submissionDocument, fileType);
-  if (file) return await getFileContent(file);
-}
-async function getPartWithoutLogical(submissionDocument, fileType) {
-  const file = await getFileResource(submissionDocument, fileType);
-  if (file) return await getFileContentPhysical(file);
+  const { logicalFile, physicalFile } = await getFileResource(submissionDocument, fileType);
+  if (physicalFile) return await getFileContentPhysical(physicalFile);
 }
 
 /**
@@ -316,17 +312,21 @@ async function getFileResource(submissionDocument, fileType) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT DISTINCT ?logicalFile
+    SELECT DISTINCT ?logicalFile ?physicalFile
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
+        OPTIONAL { ?physicalFile nie:dataSource ?logicalFile . }
       }
       ?logicalFile dct:type ${sparqlEscapeUri(fileType)} .
     }
   `);
 
   if (result.results.bindings.length) {
-    return result.results.bindings[0]['logicalFile'].value;
+    return {
+      logicalFile: result.results.bindings[0]?.logicalFile?.value,
+      physicalFile: result.results.bindings[0]?.physicalFile?.value,
+    };
   } else {
     console.log(`Part of type ${fileType} for submission document ${submissionDocument} not found`);
   }
@@ -355,25 +355,28 @@ async function savePart(submissionDocument, content, fileType) {
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-    SELECT ?logicalFile
+    SELECT ?logicalFile ?physicalFile
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
-        ?logicalFile dct:type ${sparqlEscapeUri(fileType)} .
+        ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
+        ?physicalFile
+          nie:dataSource ?logicalFile ;
+          dct:type ${sparqlEscapeUri(fileType)} .
       }
     }
   `);
 
   if (!result.results.bindings.length) {
-    const logicalFileUri = await insertTtlFile(submissionDocument, content);
+    const { logicalFile, physicalFile } = await insertTtlFile(submissionDocument, content);
     await updateSudo(`
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
       INSERT {
         GRAPH ?g {
-          ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(logicalFileUri)} .
-          ${sparqlEscapeUri(logicalFileUri)} dct:type ${sparqlEscapeUri(fileType)} .
+          ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(physicalFile)} .
+          ${sparqlEscapeUri(logicalFile)} dct:type ${sparqlEscapeUri(fileType)} .
+          ${sparqlEscapeUri(physicalFile)} dct:type ${sparqlEscapeUri(fileType)} .
         }
       } WHERE {
         GRAPH ?g {
@@ -381,11 +384,12 @@ async function savePart(submissionDocument, content, fileType) {
         }
       }
     `);
-    return logicalFileUri;
+    return { logicalFile, physicalFile };
   } else {
     const logicalFile = result.results.bindings[0]['logicalFile'].value;
+    const physicalFile = results.results.bindings[0]['physicalFile'].value;
     await updateTtlFile(submissionDocument, logicalFile, content);
-    return logicalFile;
+    return { logicalFile, physicalFile };
   }
 }
 

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -318,7 +318,7 @@ async function getFileResource(submissionDocument, fileType) {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
         OPTIONAL { ?physicalFile nie:dataSource ?logicalFile . }
       }
-      ?logicalFile dct:type ${sparqlEscapeUri(fileType)} .
+      ?physicalFile dct:type ${sparqlEscapeUri(fileType)} .
     }
   `);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,7 @@ export async function saveError({message, detail, reference}) {
         ${mu.sparqlEscapeUri(uri)}
           a oslc:Error ;
           mu:uuid ${mu.sparqlEscapeString(id)} ;
-          dct:subject ${mu.sparqlEscapeString('Automatic Submission Service')} ;
+          dct:subject ${mu.sparqlEscapeString('Enrich Submission Service')} ;
           oslc:message ${mu.sparqlEscapeString(message)} ;
           dct:created ${mu.sparqlEscapeDateTime(new Date().toISOString())} ;
           ${reference ? `dct:references ${mu.sparqlEscapeUri(reference)} ;` : ''}


### PR DESCRIPTION
In a previous version, the imported file was linked to the Submitted Document by means of a physical file. Due to the introduction of the cogs:Job model and the interoperability with the job-controller and the dashboard, the Submitted Document was linked to a logical file, just like the task for this service.

We are now rolling back that decision because of backwards compatibility problems, but while keeping the interoperability with the dashboard and the job-controller.