### PR TITLE
Only insert in one graph

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+import * as env from 'env-var';
+
+export const GRAPH_TEMPLATE = env.get('GRAPH_TEMPLATE')
+  .example('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .default('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .asUrlString();
+
+(function checkEnvVars() {
+  if (!/~ORGANIZATION_ID~/g.test(GRAPH_TEMPLATE))
+    throw new Error(`The GRAPH_TEMPLATE environment variable ${GRAPH_TEMPLATE} does not contain a ~ORGANIZATION_ID~.`);
+})();

--- a/lib/file-helpers.js
+++ b/lib/file-helpers.js
@@ -10,11 +10,13 @@ const PUBLIC_FILES_GRAPH = process.env.PUBLIC_FILES_GRAPH || 'http://mu.semte.ch
  *
  * @param string file URI of the file to get the content for
 */
-async function getFileContent(logicalFileUri) {
+async function getFileContent(logicalFileUri, graph) {
   const response = await querySudo(`
     ${env.PREFIXES}
     SELECT ?physicalFile WHERE {
-      ?physicalFile nie:dataSource ${sparqlEscapeUri(logicalFileUri)} .
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ?physicalFile nie:dataSource ${sparqlEscapeUri(logicalFileUri)} .
+      }
     }
   `);
   const physicalFileUri = response.results.bindings[0]?.physicalFile?.value;
@@ -37,7 +39,7 @@ async function getFileContentPhysical(physicalFileUri) {
  *
  * @param string ttl Turtle to write to the file
 */
-async function insertTtlFile(submissionDocument, content) {
+async function insertTtlFile(submissionDocument, content, reqState) {
   const logicalId = uuid();
   const physicalId = uuid();
   const filename = `${physicalId}.ttl`;
@@ -61,7 +63,7 @@ async function insertTtlFile(submissionDocument, content) {
     await updateSudo(`
       ${env.PREFIXES}
       INSERT {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(physicalUri)}
             a nfo:FileDataObject ;
             mu:uuid ${sparqlEscapeString(physicalId)} ;
@@ -87,7 +89,7 @@ async function insertTtlFile(submissionDocument, content) {
         }
       }
       WHERE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
       }`);
@@ -100,11 +102,11 @@ async function insertTtlFile(submissionDocument, content) {
   return logicalUri;
 }
 
-async function updateTtlFile(submissionDocument, logicalFileUri, content) {
+async function updateTtlFile(submissionDocument, logicalFileUri, content, reqState) {
   const response = await querySudo(`
     ${env.PREFIXES}
     SELECT ?physicalUri WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
         ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         ?physicalUri nie:dataSource ${sparqlEscapeUri(logicalFileUri)} .
       }
@@ -132,7 +134,7 @@ async function updateTtlFile(submissionDocument, logicalFileUri, content) {
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
       DELETE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(physicalUri)}
             dct:modified ?modified ;
             nfo:fileSize ?fileSize .
@@ -142,7 +144,7 @@ async function updateTtlFile(submissionDocument, logicalFileUri, content) {
         }
       }
       INSERT {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(physicalUri)}
             dct:modified ${sparqlEscapeDateTime(now)} ;
             nfo:fileSize ${sparqlEscapeInt(fileSize)} .
@@ -152,7 +154,7 @@ async function updateTtlFile(submissionDocument, logicalFileUri, content) {
         }
       }
       WHERE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
       }
@@ -167,10 +169,10 @@ async function updateTtlFile(submissionDocument, logicalFileUri, content) {
 /**
  * Deletes a ttl file in the triplestore and on disk
 */
-async function deleteTtlFile(logicalFile) {
+async function deleteTtlFile(logicalFile, reqState) {
   const response = await query(`
     SELECT ?physicalUri WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
         ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         ?physicalUri nie:dataSource ${sparqlEscapeUri(logicalFile)} .
       }
@@ -189,8 +191,10 @@ async function deleteTtlFile(logicalFile) {
   try {
     await update(`
       DELETE WHERE {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(physicalUri)} ?p1 ?o1 .
           ${sparqlEscapeUri(logicalUri)} ?p2 ?o2 .
+        }
       }
     `);
   } catch (e) {

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -4,6 +4,7 @@ import enrich from './enricher';
 import { PUBLIC_FILES_GRAPH, getFileContent, getFileContentPhysical, insertTtlFile, updateTtlFile, deleteTtlFile } from './file-helpers';
 import fs from 'fs-extra';
 import * as env from '../env.js';
+import * as config from '../config';
 
 const CONCEPT_STATUS = 'http://lblod.data.gift/concepts/79a52da4-f491-4e2f-9374-89a13cde8ecd';
 const SUBMITABLE_STATUS = 'http://lblod.data.gift/concepts/f6330856-e261-430f-b949-8e510d20d0ff';
@@ -34,25 +35,27 @@ export default class SubmissionDocument {
  * In case the submission is still in concept status, the harvested data (if any), additions and removals are returned.
  * In case the submission is already submitted, the submitted data is returned.
 */
-export async function getSubmissionDocument(uuid) {
-  const { submissionDocument, status } = await getSubmissionDocumentById(uuid);
+export async function getSubmissionDocument(uuid, reqState) {
+  const { submissionDocument, status, organisationId } = await getSubmissionDocumentById(uuid);
+  if (!reqState.submissionGraph)
+    reqState.submissionGraph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationId);
 
   if (submissionDocument) {
     console.log('Status of submission document is ' + status);
     if (status == CONCEPT_STATUS || status == SUBMITABLE_STATUS) {
       console.log('Form is in concept status. Getting harvested data and additions/removals.');
-      const formFile = await getFormFile(submissionDocument);
-      const form = await calculateActiveForm(submissionDocument, formFile);
-      const { meta } = await calculateMetaSnapshot(submissionDocument);
-      const source = await getHarvestedData(submissionDocument);
-      const additions = await getAdditions(submissionDocument);
-      const removals = await getRemovals(submissionDocument);
+      const formFile = await getFormFile(submissionDocument, reqState);
+      const form = await calculateActiveForm(submissionDocument, formFile, reqState);
+      const { meta } = await calculateMetaSnapshot(submissionDocument, reqState);
+      const source = await getHarvestedData(submissionDocument, reqState);
+      const additions = await getAdditions(submissionDocument, reqState);
+      const removals = await getRemovals(submissionDocument, reqState);
       return new SubmissionDocument(form, meta, source, additions, removals);
     } else {
       console.log('Form is in sent status. Getting submitted form data.');
-      const form = await getSubmittedForm(submissionDocument);
-      const meta = await getSubmittedMeta(submissionDocument);
-      const source = await getSubmittedFormData(submissionDocument);
+      const form = await getSubmittedForm(submissionDocument, reqState);
+      const meta = await getSubmittedMeta(submissionDocument, reqState);
+      const source = await getSubmittedFormData(submissionDocument, reqState);
       return new SubmissionDocument(form, meta, source);
     }
   } else {
@@ -66,23 +69,25 @@ export async function getSubmissionDocument(uuid) {
  *
  * @return {Object} Object containing the submission document URI and submission status
 */
-export async function deleteSubmissionDocument(uuid) {
-  const { submissionDocument, status } = await getSubmissionDocumentById(uuid);
+export async function deleteSubmissionDocument(uuid, reqState) {
+  const { submissionDocument, status, organisationId } = await getSubmissionDocumentById(uuid);
+  if (!reqState.submissionGraph)
+    reqState.submissionGraph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationId);
 
   if (submissionDocument) {
     console.log('Status of submission document is ' + status);
     if (status == SENT_STATUS) {
       console.log(`Form with uuid ${uuid} is in sent status and can\'t be deleted.`);
     } else {
-      const additionsFile = await getFileResource(submissionDocument, ADDITIONS_FILE_TYPE);
-      const removalsFile = await getFileResource(submissionDocument, REMOVALS_FILE_TYPE);
-      const metaFile = await getFileResource(submissionDocument, META_FILE_TYPE);
-      const sourceFile = await getFileResource(submissionDocument, FORM_DATA_FILE_TYPE);
+      const additionsFile = await getFileResource(submissionDocument, ADDITIONS_FILE_TYPE, reqState);
+      const removalsFile = await getFileResource(submissionDocument, REMOVALS_FILE_TYPE, reqState);
+      const metaFile = await getFileResource(submissionDocument, META_FILE_TYPE, reqState);
+      const sourceFile = await getFileResource(submissionDocument, FORM_DATA_FILE_TYPE, reqState);
 
-      if (additionsFile) deleteTtlFile(additionsFile);
-      if (removalsFile) deleteTtlFile(removalsFile);
-      if (metaFile) deleteTtlFile(metaFile);
-      if (sourceFile) deleteTtlFile(sourceFile);
+      if (additionsFile) deleteTtlFile(additionsFile, reqState);
+      if (removalsFile) deleteTtlFile(removalsFile, reqState);
+      if (metaFile) deleteTtlFile(metaFile, reqState);
+      if (sourceFile) deleteTtlFile(sourceFile, reqState);
 
       deleteSubmissionDocumentResource(submissionDocument); //TODO: async function, deliberate no wait?
     }
@@ -99,9 +104,9 @@ export async function deleteSubmissionDocument(uuid) {
  * When the submission is submitted, the metadata snapshot is frozen and can no longer
  * be updated.
 */
-export async function calculateMetaSnapshot(submissionDocument) {
+export async function calculateMetaSnapshot(submissionDocument, reqState) {
   const content = await enrich(submissionDocument);
-  const logicalFileUri = await saveMeta(submissionDocument, content);
+  const logicalFileUri = await saveMeta(submissionDocument, content, reqState);
   return { meta: content, logicalFileUri };
 }
 
@@ -110,30 +115,36 @@ export async function calculateMetaSnapshot(submissionDocument) {
  *
  * @return {string} TTL with the current form
  */
-export async function calculateActiveForm(submissionDocument, formFile = ACTIVE_FORM_FILE) {
-    await saveForm(submissionDocument, formFile);
+export async function calculateActiveForm(submissionDocument, formFile = ACTIVE_FORM_FILE, reqState) {
+    await saveForm(submissionDocument, formFile, reqState);
     return await getFileContentPhysical(formFile);
 }
 
-export async function getSubmissionDocumentFromTask(taskUri) {
+export async function getSubmissionDocumentInfoFromTask(taskUri) {
   const response = await querySudo(`
     ${env.PREFIXES}
-    SELECT ?submissionDocument
+    SELECT ?submissionDocument ?organisationId
     WHERE {
       GRAPH ?g {
         ${sparqlEscapeUri(taskUri)}
           a task:Task ;
           dct:isPartOf ?job .
         ?job prov:generated ?submission .
-        ?submission dct:subject ?submissionDocument .
+        ?submission
+          dct:subject ?submissionDocument ;
+          pav:createdBy ?bestuurseenheid .
       }
+      ?bestuurseenheid mu:uuid ?organisationId .
     } LIMIT 1
   `);
 
   const bindings = response?.results?.bindings;
   if (bindings && bindings.length > 0) {
     const binding = bindings[0];
-    return binding.submissionDocument.value;
+    return {
+      submissionDocument: binding.submissionDocument.value,
+      organisationId: binding.organisationId.value,
+    };
   }
 }
 
@@ -149,24 +160,24 @@ export async function getSubmissionDocumentFromTask(taskUri) {
 */
 async function getSubmissionDocumentById(uuid) {
   const result = await querySudo(`
-    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-    PREFIX dct: <http://purl.org/dc/terms/>
-    PREFIX adms: <http://www.w3.org/ns/adms#>
-
-    SELECT ?submissionDocument ?status
+    ${env.PREFIXES}
+    SELECT ?submissionDocument ?status ?organisationId
     WHERE {
       GRAPH ?g {
         ?submissionDocument mu:uuid ${sparqlEscapeString(uuid)} .
-        ?submission dct:subject ?submissionDocument ;
-                    adms:status ?status .
+        ?submission
+          dct:subject ?submissionDocument ;
+          adms:status ?status ;
+          pav:createdBy ?bestuurseenheid .
       }
-    }
-  `);
+      ?bestuurseenheid mu:uuid ?organisationId .
+    }`);
 
   if (result.results.bindings.length) {
     return {
       submissionDocument: result.results.bindings[0]['submissionDocument'].value,
-      status: result.results.bindings[0]['status'].value
+      status: result.results.bindings[0]['status'].value,
+      organisationId: result.results.bindings[0].organisationId.value,
     };
   } else {
     return {
@@ -176,7 +187,7 @@ async function getSubmissionDocumentById(uuid) {
   }
 }
 
-async function saveForm(submissionDocument, formFile) {
+async function saveForm(submissionDocument, formFile, reqState) {
   await updateSudo(`
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -192,14 +203,14 @@ async function saveForm(submissionDocument, formFile) {
       }
       ;
       INSERT {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(formFile)} .
         }
         GRAPH ${sparqlEscapeUri(PUBLIC_FILES_GRAPH)} {
           ${sparqlEscapeUri(formFile)} dct:type ${sparqlEscapeUri(FORM_FILE_TYPE)} .
         }
       } WHERE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
       }
@@ -213,14 +224,14 @@ async function saveForm(submissionDocument, formFile) {
  * @param {string} submissionDocument URI of the submitted document to get the harvested data for
  * @return {string} TTL with harvested data for the given submission document
 */
-async function getHarvestedData(submissionDocument) {
+async function getHarvestedData(submissionDocument, reqState) {
   const result = await query(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
     SELECT DISTINCT ?logicalFile
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
         ?logicalFile dct:type <http://data.lblod.gift/concepts/harvested-data> .
       }
@@ -229,7 +240,7 @@ async function getHarvestedData(submissionDocument) {
 
   if (result.results.bindings.length) {
     const file = result.results.bindings[0]['logicalFile'].value;
-    return await getFileContent(file);
+    return await getFileContent(file, reqState.submissionGraph);
   }
 }
 
@@ -240,8 +251,8 @@ async function getHarvestedData(submissionDocument) {
  * @param {string} submissionDocument URI of the submitted document to get the additions for
  * @return {string} TTL with additions for the given submission document
 */
-function getAdditions(submissionDocument) {
-  return getPart(submissionDocument, ADDITIONS_FILE_TYPE);
+function getAdditions(submissionDocument, reqState) {
+  return getPart(submissionDocument, ADDITIONS_FILE_TYPE, reqState);
 }
 
 /**
@@ -251,8 +262,8 @@ function getAdditions(submissionDocument) {
  * @param {string} submissionDocument URI of the submitted document to get the removals for
  * @return {string} TTL with removals for the given submission document
 */
-function getRemovals(submissionDocument) {
-  return getPart(submissionDocument, REMOVALS_FILE_TYPE);
+function getRemovals(submissionDocument, reqState) {
+  return getPart(submissionDocument, REMOVALS_FILE_TYPE, reqState);
 }
 
 /**
@@ -261,8 +272,8 @@ function getRemovals(submissionDocument) {
  * @param {string} submissionDocument URI of the submitted document to get the form data for
  * @return {string} TTL with the form used to submit the document
 */
-function getSubmittedForm(submissionDocument) {
-  return getPartWithoutLogical(submissionDocument, FORM_FILE_TYPE);
+function getSubmittedForm(submissionDocument, reqState) {
+  return getPartWithoutLogical(submissionDocument, FORM_FILE_TYPE, reqState);
 }
 
 /**
@@ -272,8 +283,8 @@ function getSubmittedForm(submissionDocument) {
  * @param {string} submissionDocument URI of the submitted document to get the form data for
  * @return {string} TTL with the meta data used to validate the form
 */
-async function getSubmittedMeta(submissionDocument) {
-  return getPart(submissionDocument, META_FILE_TYPE);
+async function getSubmittedMeta(submissionDocument, reqState) {
+  return getPart(submissionDocument, META_FILE_TYPE, reqState);
 }
 
 /**
@@ -283,8 +294,8 @@ async function getSubmittedMeta(submissionDocument) {
  * @param {string} submissionDocument URI of the submitted document to get the form data for
  * @return {string} TTL with submitted form data
 */
-async function getSubmittedFormData(submissionDocument) {
-  return getPart(submissionDocument, FORM_DATA_FILE_TYPE);
+async function getSubmittedFormData(submissionDocument, reqState) {
+  return getPart(submissionDocument, FORM_DATA_FILE_TYPE, reqState);
 }
 
 /**
@@ -294,12 +305,12 @@ async function getSubmittedFormData(submissionDocument) {
  * @param {string} fileType URI of the type of the related file
  * @return {string} Content of the related file
 */
-async function getPart(submissionDocument, fileType) {
-  const file = await getFileResource(submissionDocument, fileType);
-  if (file) return await getFileContent(file);
+async function getPart(submissionDocument, fileType, reqState) {
+  const file = await getFileResource(submissionDocument, fileType, reqState);
+  if (file) return await getFileContent(file, reqState.submissionGraph);
 }
-async function getPartWithoutLogical(submissionDocument, fileType) {
-  const file = await getFileResource(submissionDocument, fileType);
+async function getPartWithoutLogical(submissionDocument, fileType, reqState) {
+  const file = await getFileResource(submissionDocument, fileType, reqState);
   if (file) return await getFileContentPhysical(file);
 }
 
@@ -310,7 +321,7 @@ async function getPartWithoutLogical(submissionDocument, fileType) {
  * @param {string} fileType URI of the type of the related file
  * @return {string} File full name (path, name and extention)
 */
-async function getFileResource(submissionDocument, fileType) {
+async function getFileResource(submissionDocument, fileType, reqState) {
   const result = await querySudo(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -318,7 +329,7 @@ async function getFileResource(submissionDocument, fileType) {
 
     SELECT DISTINCT ?logicalFile
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
       }
       ?logicalFile dct:type ${sparqlEscapeUri(fileType)} .
@@ -338,8 +349,8 @@ async function getFileResource(submissionDocument, fileType) {
  * @param {string} submissionDocument URI of the submitted document to write the meta data for
  * @param {string} content Meta data in TTL format
 */
-function saveMeta(submissionDocument, content) {
-  return savePart(submissionDocument, content, META_FILE_TYPE);
+function saveMeta(submissionDocument, content, reqState) {
+  return savePart(submissionDocument, content, META_FILE_TYPE, reqState);
 }
 
 /**
@@ -349,7 +360,7 @@ function saveMeta(submissionDocument, content) {
  * @param {string} content Content to write to the file
  * @param {string} fileType URI of the type of the related file
 */
-async function savePart(submissionDocument, content, fileType) {
+async function savePart(submissionDocument, content, fileType, reqState) {
   const result = await querySudo(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -357,7 +368,7 @@ async function savePart(submissionDocument, content, fileType) {
 
     SELECT ?logicalFile
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?logicalFile .
         ?logicalFile dct:type ${sparqlEscapeUri(fileType)} .
       }
@@ -365,18 +376,18 @@ async function savePart(submissionDocument, content, fileType) {
   `);
 
   if (!result.results.bindings.length) {
-    const logicalFileUri = await insertTtlFile(submissionDocument, content);
+    const logicalFileUri = await insertTtlFile(submissionDocument, content, reqState);
     await updateSudo(`
       PREFIX dct: <http://purl.org/dc/terms/>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
       INSERT {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(submissionDocument)} dct:source ${sparqlEscapeUri(logicalFileUri)} .
           ${sparqlEscapeUri(logicalFileUri)} dct:type ${sparqlEscapeUri(fileType)} .
         }
       } WHERE {
-        GRAPH ?g {
+        GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
           ${sparqlEscapeUri(submissionDocument)} a ext:SubmissionDocument .
         }
       }
@@ -384,7 +395,7 @@ async function savePart(submissionDocument, content, fileType) {
     return logicalFileUri;
   } else {
     const logicalFile = result.results.bindings[0]['logicalFile'].value;
-    await updateTtlFile(submissionDocument, logicalFile, content);
+    await updateTtlFile(submissionDocument, logicalFile, content, reqState);
     return logicalFile;
   }
 }
@@ -394,15 +405,15 @@ async function savePart(submissionDocument, content, fileType) {
  *
  * @param {string} submissionDocument URI of the submitted document to get the related file for
 */
-async function deleteSubmissionDocumentResource(submissionDocument) {
+async function deleteSubmissionDocumentResource(submissionDocument, reqState) {
   const result = await querySudo(`
     DELETE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
         ${sparqlEscapeUri(submissionDocument)} ?p ?o .
       }
     }
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
         ${sparqlEscapeUri(submissionDocument)} ?p ?o .
       }
     }
@@ -414,7 +425,7 @@ async function deleteSubmissionDocumentResource(submissionDocument) {
  *
  * @param {string} submissionDocument URI of the submitted document to write the related file for
 */
-async function getFormFile(submissionDocument) {
+async function getFormFile(submissionDocument, reqState) {
   const result = await querySudo(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -422,7 +433,7 @@ async function getFormFile(submissionDocument) {
 
     SELECT ?file
     WHERE {
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?file .
       }
       ?file dct:type ${sparqlEscapeUri(FORM_FILE_TYPE)} .

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -120,10 +120,10 @@ export async function calculateActiveForm(submissionDocument, formFile = ACTIVE_
     return await getFileContentPhysical(formFile);
 }
 
-export async function getSubmissionDocumentInfoFromTask(taskUri) {
+export async function getSubmissionDocumentFromTask(taskUri) {
   const response = await querySudo(`
     ${env.PREFIXES}
-    SELECT ?submissionDocument ?organisationId
+    SELECT ?submissionDocument
     WHERE {
       GRAPH ?g {
         ${sparqlEscapeUri(taskUri)}
@@ -141,10 +141,7 @@ export async function getSubmissionDocumentInfoFromTask(taskUri) {
   const bindings = response?.results?.bindings;
   if (bindings && bindings.length > 0) {
     const binding = bindings[0];
-    return {
-      submissionDocument: binding.submissionDocument.value,
-      organisationId: binding.organisationId.value,
-    };
+    return binding.submissionDocument.value;
   }
 }
 

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -9,7 +9,7 @@ import * as env from '../env.js';
  * @param string status URI of the new status
  * @param string or undefined URI of the error that needs to be attached
 */
-export async function updateTaskStatus(taskUri, status, errorUri, logicalFileUri) {
+export async function updateTaskStatus(taskUri, status, errorUri, logicalFileUri, graph) {
   const taskUriSparql = mu.sparqlEscapeUri(taskUri);
   const nowSparql = mu.sparqlEscapeDateTime((new Date()).toISOString());
   const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
@@ -30,14 +30,14 @@ export async function updateTaskStatus(taskUri, status, errorUri, logicalFileUri
   const statusUpdateQuery = `
     ${env.PREFIXES}
     DELETE {
-      GRAPH ?g {
+      GRAPH ${mu.sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ?oldStatus ;
           dct:modified ?oldModified .
       }
     }
     INSERT {
-      GRAPH ?g {
+      GRAPH ${mu.sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ${mu.sparqlEscapeUri(status)} ;
           ${hasError ? `task:error ${mu.sparqlEscapeUri(errorUri)} ;` : ''}
@@ -48,7 +48,7 @@ export async function updateTaskStatus(taskUri, status, errorUri, logicalFileUri
       }
     }
     WHERE {
-      GRAPH ?g {
+      GRAPH ${mu.sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ?oldStatus ;
           dct:modified ?oldModified .
@@ -56,4 +56,18 @@ export async function updateTaskStatus(taskUri, status, errorUri, logicalFileUri
     }
   `;
   await mas.updateSudo(statusUpdateQuery);
+}
+
+export async function getOrganisationIdFromTask(taskUri) {
+  const response = await mas.querySudo(`
+    ${env.PREFIXES}
+    SELECT DISTINCT ?organisationId WHERE {
+      ${mu.sparqlEscapeUri(taskUri)} dct:isPartOf ?job .
+      ?job prov:generated ?submission .
+      ?submission pav:createdBy ?bestuurseenheid .
+      ?bestuurseenheid mu:uuid ?organisationId .
+    }
+    LIMIT 1
+  `);
+  return response?.results?.bindings[0]?.organisationId?.value;
 }

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -57,4 +57,3 @@ export async function updateTaskStatus(taskUri, status, errorUri, logicalFileUri
   `;
   await mas.updateSudo(statusUpdateQuery);
 }
-

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.2.0",
     "body-parser": "1.19.0",
+    "env-var": "^7.3.0",
     "event-stream": "^4.0.1",
     "fs-extra": "8.1.0",
     "lodash.flatten": "^4.4.0",
-    "request": "^2.88.0",
-    "rdflib": "1.1.0"
+    "rdflib": "1.1.0",
+    "request": "^2.88.0"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   }


### PR DESCRIPTION
In order to improve data security, the services in the automatic submission flow should only insert data in one specific controlled graph.

This fixes issues related to data spreading in graphs that should not contain that data. More specific for the vendor-data-distribution-service.

This PR includes a configuration file where the graph template is loaded from environment variables, but with sensible defaults so that nothing special should be done in most cases. The code is adapted to always compute the graph from the template in combination with the organisation ID before inserting into the triplestore.