### PR TITLE
Fixing Erediensten filter 

### DIFF
--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -185,6 +185,10 @@ async function getBestuurseenheidFor(submissionDocument) {
   }
 }
 
+/**
+ * Filters the input form field values to display only the ones with following URI <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
+ * that represents the local involvement "Toezichthoudend"
+ */
 async function addFilteredEredienstenAndCentraleBesturenGOAndPO(submissionDocument, store) {
   console.log(`Adding linked worship-services to meta graph`);
   const bestuurseenheid = await getBestuurseenheidFor(submissionDocument);
@@ -196,9 +200,7 @@ async function addFilteredEredienstenAndCentraleBesturenGOAndPO(submissionDocume
             <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
         }
         VALUES ?typeBetrokkenheid {
-            <http://lblod.data.gift/concepts/86fcbbbff764f1cba4c7e10dbbae578e>
             <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
-            <http://lblod.data.gift/concepts/0f845f00ee76099c89518cbaf6a7b77f>
         }
         ${sparqlEscapeUri(bestuurseenheid)} <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur.
         ?betrokkenBestuur <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeBetrokkenheid;
@@ -235,6 +237,10 @@ async function addFilteredEredienstenAndCentraleBesturenGOAndPO(submissionDocume
 
 }
 
+/**
+ * Filters the input form field values to display only the ones with following URI <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
+ * that represents the local involvement "Toezichthoudend"
+ */
 async function addFilteredEredienstenGOAndPO(submissionDocument, store) {
   console.log(`Adding linked worship-services to meta graph`);
   const bestuurseenheid = await getBestuurseenheidFor(submissionDocument);
@@ -245,9 +251,7 @@ async function addFilteredEredienstenGOAndPO(submissionDocument, store) {
           <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
       }
       VALUES ?typeBetrokkenheid {
-          <http://lblod.data.gift/concepts/86fcbbbff764f1cba4c7e10dbbae578e>
           <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
-          <http://lblod.data.gift/concepts/0f845f00ee76099c89518cbaf6a7b77f>
       }
       ${sparqlEscapeUri(bestuurseenheid)} <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur.
       ?betrokkenBestuur <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeBetrokkenheid;

--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -199,9 +199,7 @@ async function addFilteredEredienstenAndCentraleBesturenGOAndPO(submissionDocume
             <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
             <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
         }
-        VALUES ?typeBetrokkenheid {
-            <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
-        }
+        BIND(<http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1> AS ?typeBetrokkenheid) 
         ${sparqlEscapeUri(bestuurseenheid)} <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur.
         ?betrokkenBestuur <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeBetrokkenheid;
             <http://www.w3.org/ns/org#organization> ?erediensten.
@@ -250,9 +248,7 @@ async function addFilteredEredienstenGOAndPO(submissionDocument, store) {
       VALUES ?classificatie {
           <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
       }
-      VALUES ?typeBetrokkenheid {
-          <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
-      }
+      BIND(<http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1> AS ?typeBetrokkenheid)
       ${sparqlEscapeUri(bestuurseenheid)} <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur.
       ?betrokkenBestuur <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeBetrokkenheid;
           <http://www.w3.org/ns/org#organization> ?erediensten.


### PR DESCRIPTION
# Description
DL-5060

This PR is about fixing the Eredienst filter for "Bestuur van Eredienst" and "Centrale Bestuur van Eredienst" based on the local involvement type. 

## Context 

When creating a submission related to Erediensten via Gemeente/Provincie; the dropdownlist in `Betreffend bestuur van de eredienst` &  `Betreffend (centraal) bestuur van de eredienst` should only show worship services with the type of Local Involvement = `Toezichthoudend`.

# Type of change

    [x] Bug fix (non-breaking change which fixes an issue)
    [] New feature (non-breaking change which adds functionality)
    [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
    [] Other

# Related services

N/A

# How to test

1. Build the image from this branch and add it into app-digitaal-loket.

2. Run loket.

3. Log in with a gemeente or provincie.

4. Start a new submission of the type:
    - Advies bij jaarrekening eredienstbestuur
    - Besluit over budget(wijziging) eredienstbestuur
    - Besluit over meerjarenplan(aanpassing) eredienstbestuur
    - Schorsing beslissing eredienstbesturen

5. Check the listed services in the dropdownlist for  ‘Betreffend bestuur van de eredienst’ OR ‘Betreffend (centraal) bestuur van de eredienst’.

Example; From Gemeente Herent :

```sparql
  SELECT DISTINCT ?erediensten ?label ?classificatie WHERE {
    GRAPH ?g {
        VALUES ?classificatie {
            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
        }
        VALUES ?typeBetrokkenheid {
            <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
        }
        <http://data.lblod.info/id/bestuurseenheden/56423901b281897688074e6ce6811a6a33eec4070da7e22c4fae65050d7b712f> <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur.
        ?betrokkenBestuur <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeBetrokkenheid;
            <http://www.w3.org/ns/org#organization> ?erediensten.
        ?erediensten <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie;
            <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
    }
  }
```

Result; Where URI <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1> is `Toezichthoudend`:

erediensten | label | classificatie | typeBetrokkenheid
-- | -- | -- | --
http://data.lblod.info/id/besturenVanDeEredienst/819f1bb12ac62cf130339ef0033fcbde | "Kerkfabriek St.-Michiel van Herent (Veltem-Beisem)" | http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86 | http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1
http://data.lblod.info/id/besturenVanDeEredienst/1ccfe6d166b1bfd797fb0f6edb60f96d | "Kerkfabriek Maria-Hemelvaart van Herent (Winksele)" | http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86 | http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1
http://data.lblod.info/id/besturenVanDeEredienst/25052fa8ca19d445d1ad31138db07182 | "Kerkfabriek O.-L.-Vrouw van Herent" | http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86 | http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1
http://data.lblod.info/id/centraleBesturenVanDeEredienst/203429fa110020c33f7e8ff59a47c5e5 | "CKB Herent" | http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054 | http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1
http://data.lblod.info/id/besturenVanDeEredienst/d0dca45d978f8a7a33d04dd59aecb346 | "Kerkfabriek St.-Laurentius van Herent (Veltem-Beisem)" | http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86 | http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1
http://data.lblod.info/id/besturenVanDeEredienst/0ae74394ec4f52d2a2f1e8c3707cadec | "Kerkfabriek H. Hart van Herent (Winksele)" | http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86 | http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1


# Links to other PR's

N/A

# Notes

After merging, the loket enrich-submission-service image must then be updated.
