### PR TITLE
Adding new codelist for case of collective energy renovation

### DIFF
--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -20,6 +20,7 @@ const TOEZICHT_CONCEPT_SCHEMES = [
   'http://lblod.data.gift/concept-schemes/0b93ef1c-4435-4922-8611-31b4f3ca3c85', // Explanation type LEKP
   'http://lblod.data.gift/concept-schemes/1dfc51af-99fd-4be9-a681-41360c195f14', // Correction type LEKP
   'http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced', // Inhoud besluit (over budget wijziging - Akteneming, Aanpassingsbesluit and Goedkeuringsbesluit)
+  'http://lblod.data.gift/concept-schemes/56ef78a0-5ab4-4548-b995-fd995703183c', // LEKP Collectieve energierenovatie
 ];
 
 const EREDIENSTEN_AND_CENTRALE_BESTUREN_FILTERED_GO_PO_SCHEME =


### PR DESCRIPTION
# Description

DL-5499

This PR adds the following codelist `http://lblod.data.gift/concept-schemes/56ef78a0-5ab4-4548-b995-fd995703183c` for the form `LEKP-rapport - Collectieve energiebesparende renovatie` 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. Use the image into the docker-compose.override.yml of app-digitaal-loket
2. Make sure codelist migration from Loket ran without issues
3. The form should show the following options
```
Het betreft een : [Verplicht]
( ) Energiebesparende collectieve renovatie
( ) Fossielvrije energiebesparende collectieve renovatie
```
4. Save the form, it should be saved without errors.
5. Send the form, it should be consumed by app-toezicht-abb and not by app-public-decisions-database.
a. To consume the form you can follow the docs @ https://github.com/lblod/app-toezicht-abb#trigger-import-export-flow-from-app-digitaal-loket

**Form**

![Screenshot 2023-12-15 at 11-45-27 Loket voor lokale besturen](https://github.com/lblod/enrich-submission-service/assets/38471754/e675c1ad-78ed-4bd3-b325-6b06554dbd86)

 
# What to check

- Typos, and form structure  

# Links to other PR's

- N/A

# Notes

Release + Bump in Loket