### PR TITLE
Relax graph restriction on reads

### DIFF
--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -319,10 +319,11 @@ async function getFileResource(submissionDocument, fileType, reqState) {
 
     SELECT DISTINCT ?logicalFile ?physicalFile
     WHERE {
-      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
+      GRAPH ?g {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?physicalFile .
         OPTIONAL { ?physicalFile nie:dataSource ?logicalFile . }
       }
+      FILTER (REGEX(STR(?g), "${reqState.organisationId}"))
       ?physicalFile dct:type ${sparqlEscapeUri(fileType)} .
     }
   `);
@@ -407,14 +408,15 @@ async function savePart(submissionDocument, content, fileType, reqState) {
 async function deleteSubmissionDocumentResource(submissionDocument, reqState) {
   const result = await querySudo(`
     DELETE {
-      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
+      GRAPH ?g {
         ${sparqlEscapeUri(submissionDocument)} ?p ?o .
       }
     }
     WHERE {
-      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
+      GRAPH ?g {
         ${sparqlEscapeUri(submissionDocument)} ?p ?o .
       }
+      FILTER (REGEX(STR(?g), "${reqState.organisationId}"))
     }
   `);
 }
@@ -432,9 +434,10 @@ async function getFormFile(submissionDocument, reqState) {
 
     SELECT ?file
     WHERE {
-      GRAPH ${sparqlEscapeUri(reqState.submissionGraph)} {
+      GRAPH ?g {
         ${sparqlEscapeUri(submissionDocument)} dct:source ?file .
       }
+      FILTER (REGEX(STR(?g), "${reqState.organisationId}"))
       ?file dct:type ${sparqlEscapeUri(FORM_FILE_TYPE)} .
     }
   `);

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -37,6 +37,7 @@ export default class SubmissionDocument {
 */
 export async function getSubmissionDocument(uuid, reqState) {
   const { submissionDocument, status, organisationId } = await getSubmissionDocumentById(uuid);
+  reqState.organisationId = organisationId;
   if (!reqState.submissionGraph)
     reqState.submissionGraph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationId);
 
@@ -71,6 +72,7 @@ export async function getSubmissionDocument(uuid, reqState) {
 */
 export async function deleteSubmissionDocument(uuid, reqState) {
   const { submissionDocument, status, organisationId } = await getSubmissionDocumentById(uuid);
+  reqState.organisationId = organisationId;
   if (!reqState.submissionGraph)
     reqState.submissionGraph = config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', organisationId);
 

--- a/lib/submission-document.js
+++ b/lib/submission-document.js
@@ -168,20 +168,14 @@ async function getSubmissionDocumentById(uuid) {
           pav:createdBy ?bestuurseenheid .
       }
       ?bestuurseenheid mu:uuid ?organisationId .
-    }`);
+    }
+    LIMIT 1`);
 
-  if (result.results.bindings.length) {
-    return {
-      submissionDocument: result.results.bindings[0]['submissionDocument'].value,
-      status: result.results.bindings[0]['status'].value,
-      organisationId: result.results.bindings[0].organisationId.value,
-    };
-  } else {
-    return {
-      submissionDocument: null,
-      status: null
-    };
-  }
+  return {
+    submissionDocument: result.results.bindings[0]?.submissionDocument?.value,
+    status: result.results.bindings[0]?.status?.value,
+    organisationId: result.results.bindings[0]?.organisationId?.value,
+  };
 }
 
 async function saveForm(submissionDocument, formFile, reqState) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enrich-submission-service",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Microservice to enrich a submission harvested from a published document.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In certain applications, this service is used to read the Submission data, but the way the graph URIs are constructed is different from Loket. E.g. in Loket a graph for an organisation looks like:

    http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker

but in the worship decisions database application this looks like:

    http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-databankEredienstenGebruiker

due to a different set-up in mu-authorization.

To make sure this service works in both applications, we relaxed the graph restriction. It is now sufficient that the organisation UUID is contained in the graph URI. As these UUID are globally unique by definition, when they are in the name of the graph, we are certain the graph belongs to the organisation at hand.