### PR TITLE
Adding new codelist "type beroepsprocedure"

### DIFF
--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -21,6 +21,7 @@ const TOEZICHT_CONCEPT_SCHEMES = [
   'http://lblod.data.gift/concept-schemes/1dfc51af-99fd-4be9-a681-41360c195f14', // Correction type LEKP
   'http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced', // Inhoud besluit (over budget wijziging - Akteneming, Aanpassingsbesluit and Goedkeuringsbesluit)
   'http://lblod.data.gift/concept-schemes/56ef78a0-5ab4-4548-b995-fd995703183c', // LEKP Collectieve energierenovatie
+  'http://lblod.data.gift/concept-schemes/ba36f197-1a96-4ea2-a7f7-3b5c7ffcd6ee'  // Type beroepsprocedure
 ];
 
 const EREDIENSTEN_AND_CENTRALE_BESTUREN_FILTERED_GO_PO_SCHEME =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enrich-submission-service",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Microservice to enrich a submission harvested from a published document.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enrich-submission-service",
-  "version": "1.8.0",
+  "version": "1.9.0-rc.1",
   "description": "Microservice to enrich a submission harvested from a published document.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

DL-5646

This PR adds the following codelist `http://lblod.data.gift/concept-schemes/ba36f197-1a96-4ea2-a7f7-3b5c7ffcd6ee` in the metagraph so it can be used in the field "type beroepsprocedure" from the form "Opstart beroepsprocedure naar aanleiding van een beslissing".

This codelist is giving three options to choose from : Meerjarenplan(wijziging)”, “Afsprakennota” and “Budget(wijziging)”

**Note : This PR needs to be merged with the form bundle  "Links to other PR's" Section**

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. In Loket, log in as Gemeente
2. Create a submission "Opstart beroepsprocedure naar aanleiding van een beslissing"
3. The field "type beroepsprocedure" should show the 3 options
4. Sending the form shows no errors

# What to check

- N/A

# Links to other PR's

- Manage-submissions-form-tooling -> https://github.com/lblod/manage-submission-form-tooling/pull/44
- App-digitaal-loket -> https://github.com/lblod/app-digitaal-loket/pull/528
- App-meldingsplichtige -> https://github.com/lblod/app-meldingsplichtige-api/pull/41
- App-toezicht-ABB -> https://github.com/lblod/app-toezicht-abb/pull/38
- App-public-decisions-database -> https://github.com/lblod/app-public-decisions-database/pull/25
- App-worship-decisions-database -> https://github.com/lblod/app-worship-decisions-database/pull/59
- Prepare-submissions-for-export-service -> https://github.com/lblod/prepare-submissions-for-export-service/pull/12
- Worship-submissions-graph-dispatcher-service -> https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/18

# Notes

drc up -d enrich-submission 

Release to 1.10.0