### PR TITLE
Adding new codelist "Type afschrift" 

### DIFF
--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -21,7 +21,8 @@ const TOEZICHT_CONCEPT_SCHEMES = [
   'http://lblod.data.gift/concept-schemes/1dfc51af-99fd-4be9-a681-41360c195f14', // Correction type LEKP
   'http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced', // Inhoud besluit (over budget wijziging - Akteneming, Aanpassingsbesluit and Goedkeuringsbesluit)
   'http://lblod.data.gift/concept-schemes/56ef78a0-5ab4-4548-b995-fd995703183c', // LEKP Collectieve energierenovatie
-  'http://lblod.data.gift/concept-schemes/ba36f197-1a96-4ea2-a7f7-3b5c7ffcd6ee'  // Type beroepsprocedure
+  'http://lblod.data.gift/concept-schemes/ba36f197-1a96-4ea2-a7f7-3b5c7ffcd6ee', // Type beroepsprocedure
+  'http://lblod.data.gift/concept-schemes/27f40c36-141d-42e9-bed8-fea1a47c4869'  // Type afschrift
 ];
 
 const EREDIENSTEN_AND_CENTRALE_BESTUREN_FILTERED_GO_PO_SCHEME =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enrich-submission-service",
-  "version": "1.10.0",
+  "version": "1.11.0-rc.1",
   "description": "Microservice to enrich a submission harvested from a published document.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

DL-5670

This PR adds the following codelist `http://lblod.data.gift/concept-schemes/27f40c36-141d-42e9-bed8-fea1a47c4869` in the metagraph so it can be used in the field "type afschrift" from the form "Afschrift erkenningszoekende besturen".

This codelist is giving five options to choose from :   “Begroting en jaarrekening van de lokale geloofsgemeenschap ”, “Budget”, “Jaarrekening bestuur in wachtperiode”, “Verslag van de vergaderingen van het voorlopig bestuursorgaan”, “Ontwerp van het meerjarenplan” 

#### Preview

![Screenshot 2024-02-27 at 12-12-15 Loket voor lokale besturen](https://github.com/lblod/enrich-submission-service/assets/38471754/9a589ef7-47ea-422f-bde5-ed95c269eaeb)

**Note : This PR needs to be merged with the form bundle  "Links to other PR's" Section**

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. In Loket, log in as Bestuur van de Eredienst
2. Create a submission "Afschrift erkenningszoekende besturen"
3. The field "type afschrift" should show the 5 options
4. Sending the form shows no errors

# What to check

- N/A

# Links to other PR's

- Manage-submissions-form-tooling -> https://github.com/lblod/manage-submission-form-tooling/pull/46
- App-digitaal-loket -> https://github.com/lblod/app-digitaal-loket/pull/528
- App-meldingsplichtige -> https://github.com/lblod/app-meldingsplichtige-api/pull/41
- App-toezicht-ABB -> https://github.com/lblod/app-toezicht-abb/pull/38
- App-public-decisions-database -> https://github.com/lblod/app-public-decisions-database/pull/25
- App-worship-decisions-database -> https://github.com/lblod/app-worship-decisions-database/pull/59
- Prepare-submissions-for-export-service -> https://github.com/lblod/prepare-submissions-for-export-service/pull/13
- Worship-submissions-graph-dispatcher-service -> https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/19

# Notes

drc up -d enrich-submission 

Release to 1.11.0