### PR TITLE
Updated codelist to export

### DIFF
--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -19,10 +19,10 @@ const TOEZICHT_CONCEPT_SCHEMES = [
   'http://lblod.data.gift/concept-schemes/5d05a003-4692-4aff-9e93-325db2aefb8a', // LEKP-Goal
   'http://lblod.data.gift/concept-schemes/0b93ef1c-4435-4922-8611-31b4f3ca3c85', // Explanation type LEKP
   'http://lblod.data.gift/concept-schemes/1dfc51af-99fd-4be9-a681-41360c195f14', // Correction type LEKP
-  'http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced', // Inhoud besluit (over budget wijziging - Akteneming, Aanpassingsbesluit and Goedkeuringsbesluit)
   'http://lblod.data.gift/concept-schemes/56ef78a0-5ab4-4548-b995-fd995703183c', // LEKP Collectieve energierenovatie
   'http://lblod.data.gift/concept-schemes/ba36f197-1a96-4ea2-a7f7-3b5c7ffcd6ee', // Type beroepsprocedure
-  'http://lblod.data.gift/concept-schemes/27f40c36-141d-42e9-bed8-fea1a47c4869'  // Type afschrift
+  'http://lblod.data.gift/concept-schemes/27f40c36-141d-42e9-bed8-fea1a47c4869',  // Type afschrift
+  'http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6' // Type Artikels
 ];
 
 const EREDIENSTEN_AND_CENTRALE_BESTUREN_FILTERED_GO_PO_SCHEME =

--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -22,7 +22,12 @@ const TOEZICHT_CONCEPT_SCHEMES = [
   'http://lblod.data.gift/concept-schemes/56ef78a0-5ab4-4548-b995-fd995703183c', // LEKP Collectieve energierenovatie
   'http://lblod.data.gift/concept-schemes/ba36f197-1a96-4ea2-a7f7-3b5c7ffcd6ee', // Type beroepsprocedure
   'http://lblod.data.gift/concept-schemes/27f40c36-141d-42e9-bed8-fea1a47c4869',  // Type afschrift
-  'http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6' // Type Artikels
+  'http://data.lblod.info/concept-schemes/aeb364c6-768a-4a6b-8cbf-a681d1a6b8b6', // Type Artikels
+
+  // Note: Inoud besluit is will be obsolete eventually.
+  // If you encounter this comment, and cross-referning of documents is implmented, deployed on production, you may blindly remove this line.
+  // We keep it here in code, to not complicated the merge process, since this might really tak a while before the full feature gets merged.
+  'http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced' // Inhoud besluit (over budget wijziging - Akteneming, Aanpassingsbesluit and Goedkeuringsbesluit)
 ];
 
 const EREDIENSTEN_AND_CENTRALE_BESTUREN_FILTERED_GO_PO_SCHEME =


### PR DESCRIPTION
Cf: DL-5865
We ask enricher to export an extra list. 
Testing: Checkout https://github.com/lblod/app-digitaal-loket/pull/575, create a submission and save it.
Then go to `./app-digitaal-loket/data/files/submissions/` order the files by reverse date `ls -altr` find the most recent meta-file (it's the largest one from the latest created) and do e.g. `cat c56a56f1-190b-11ef-b6ae-e1dad1ac2703.ttl |grep 773343c9-55a4-4aaa-942c-e3a048b35c1f` The entries should appear.


