### PR TITLE
[DL-6245] Include kbo number for erediensten codelist labels

### DIFF
--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -252,7 +252,7 @@ async function addFilteredEredienstenGOAndPO(submissionDocument, store) {
   console.log(`Adding linked worship-services to meta graph`);
   const bestuurseenheid = await getBestuurseenheidFor(submissionDocument);
   const q = `
-  SELECT DISTINCT ?erediensten ?label ?classificatie WHERE {
+  SELECT DISTINCT ?erediensten ?label ?classificatie ?kboNumber WHERE {
     GRAPH ?g {
       VALUES ?classificatie {
           <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
@@ -262,7 +262,8 @@ async function addFilteredEredienstenGOAndPO(submissionDocument, store) {
       ?betrokkenBestuur <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeBetrokkenheid;
           <http://www.w3.org/ns/org#organization> ?erediensten.
       ?erediensten <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie;
-          <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+          <http://www.w3.org/2004/02/skos/core#prefLabel> ?label;
+          <http://mu.semte.ch/vocabularies/ext/kbonummer> ?kboNumber.
     }
   }
   `;
@@ -272,6 +273,8 @@ async function addFilteredEredienstenGOAndPO(submissionDocument, store) {
     const subject = binding["erediensten"].value;
     const type = binding["classificatie"].value;
     const label = binding["label"].value;
+    const kboNumber = binding["kboNumber"].value;
+    const combinedLabel = `${kboNumber} - ${label}`;
 
     store.add(
       sym(subject),
@@ -286,7 +289,12 @@ async function addFilteredEredienstenGOAndPO(submissionDocument, store) {
       sym(EREDIENSTEN_FILTERED_GO_PO_SCHEME),
       sym(defaultGraph)
     );
-    store.add(sym(subject), SKOS("prefLabel"), label , sym(defaultGraph));
+    store.add(
+      sym(subject),
+      SKOS("prefLabel"),
+      combinedLabel,
+      sym(defaultGraph)
+    );
   }
 
   return store;

--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -208,7 +208,7 @@ async function addFilteredEredienstenAndCentraleBesturenGOAndPO(submissionDocume
             <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
             <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
         }
-        BIND(<http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1> AS ?typeBetrokkenheid) 
+        BIND(<http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1> AS ?typeBetrokkenheid)
         ${sparqlEscapeUri(bestuurseenheid)} <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur.
         ?betrokkenBestuur <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeBetrokkenheid;
             <http://www.w3.org/ns/org#organization> ?erediensten.


### PR DESCRIPTION
## ID

DL-6245

## Description

Include the KBO number for erediensten codelist, this way it's easier for users to differentiate between different orgs of the same name.

## How to test

Use the following docker image inside app-digitaal-loket:
```
  enrich-submission:
    image: wolfderechter/enrich-submission-service:latest
```

1. Go to loket toezicht, create new dossier, `Advies budget(wijziging)...` for example
2. `Betreffende bestuur van de eredienst` codelist should now include the KBO numbers for the organizations

See DL-6100 (analysis ticket)  for more information.

