### PR TITLE
[DL-6416]: Include kbo number for erediensten codelist labels add kbo numbers for erediensten en centrale besturen

### DIFF
--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -317,14 +317,15 @@ async function addFilteredEredienstenRO(submissionDocument, store) {
   console.log(`Adding linked worship-services RO to meta graph`);
   const bestuurseenheid = await getBestuurseenheidFor(submissionDocument);
   const q = `
-  SELECT DISTINCT ?erediensten ?label ?classificatie WHERE {
+  SELECT DISTINCT ?erediensten ?label ?classificatie ?kboNumber WHERE {
     GRAPH ?g {
       VALUES ?classificatie {
           <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
       }
       ${sparqlEscapeUri(bestuurseenheid)} <http://www.w3.org/ns/org#linkedTo> ?erediensten.
       ?erediensten <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie;
-          <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+          <http://www.w3.org/2004/02/skos/core#prefLabel> ?label;
+          <http://mu.semte.ch/vocabularies/ext/kbonummer> ?kboNumber.
     }
   }
   `;
@@ -334,6 +335,8 @@ async function addFilteredEredienstenRO(submissionDocument, store) {
     const subject = binding["erediensten"].value;
     const type = binding["classificatie"].value;
     const label = binding["label"].value;
+    const kboNumber = binding["kboNumber"].value;
+    const combinedLabel = `${kboNumber} - ${label}`;
 
     store.add(
       sym(subject),
@@ -348,7 +351,7 @@ async function addFilteredEredienstenRO(submissionDocument, store) {
       sym(EREDIENSTEN_RO_SCHEME),
       sym(defaultGraph)
     );
-    store.add(sym(subject), SKOS("prefLabel"), label , sym(defaultGraph));
+    store.add(sym(subject), SKOS("prefLabel"), combinedLabel , sym(defaultGraph));
   }
 
   return store;

--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -207,7 +207,7 @@ async function addFilteredEredienstenAndCentraleBesturenGOAndPO(submissionDocume
   console.log(`Adding linked worship-services to meta graph`);
   const bestuurseenheid = await getBestuurseenheidFor(submissionDocument);
   const q = `
-  SELECT DISTINCT ?erediensten ?label ?classificatie WHERE {
+  SELECT DISTINCT ?erediensten ?label ?classificatie ?kboNumber WHERE {
     GRAPH ?g {
         VALUES ?classificatie {
             <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
@@ -218,7 +218,8 @@ async function addFilteredEredienstenAndCentraleBesturenGOAndPO(submissionDocume
         ?betrokkenBestuur <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeBetrokkenheid;
             <http://www.w3.org/ns/org#organization> ?erediensten.
         ?erediensten <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie;
-            <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+            <http://www.w3.org/2004/02/skos/core#prefLabel> ?label;
+            <http://mu.semte.ch/vocabularies/ext/kbonummer> ?kboNumber.
     }
   }
   `;
@@ -228,6 +229,8 @@ async function addFilteredEredienstenAndCentraleBesturenGOAndPO(submissionDocume
     const subject = binding["erediensten"].value;
     const type = binding["classificatie"].value;
     const label = binding["label"].value;
+    const kboNumber = binding["kboNumber"].value;
+    const combinedLabel = `${kboNumber} - ${label}`;
 
     store.add(
       sym(subject),
@@ -242,7 +245,12 @@ async function addFilteredEredienstenAndCentraleBesturenGOAndPO(submissionDocume
       sym(EREDIENSTEN_AND_CENTRALE_BESTUREN_FILTERED_GO_PO_SCHEME),
       sym(defaultGraph)
     );
-    store.add(sym(subject), SKOS("prefLabel"), label , sym(defaultGraph));
+    store.add(
+      sym(subject),
+      SKOS("prefLabel"),
+      combinedLabel,
+      sym(defaultGraph)
+    );
   }
 
   return store;


### PR DESCRIPTION
## ID

DL-6416

## Description

Similar to https://github.com/lblod/enrich-submission-service/pull/25, add KBO numbers in two more dropdown concept-schemes.

Use the following docker image inside app-digitaal-loket:
```
  enrich-submission:
    image: wolfderechter/enrich-submission-service:latest
```
 
Or build from the PR

## How to Test

_Centrale besturen and besturen van eredienst_
1. Login as 'Gemeente Deinze' for example
2. Go to toezicht module
3. Choose `Schorsing beslissing eredienstbesturen`
4. Open the `Betreffend (centraal) bestuur van de eredienst`
5. Verify that the dropdown now shows the kbo number for the two `CKB Deinze` options

_Erediensten selector RO (FILTERED):_
1. Login as a Representatief Orgaan, `Representatief orgaan Centraal Comité van de Anglicaanse Kerk` for example
2. Go to toezicht module
3. Create a `Adview budget(wijziging)` dossier
4. Open the `Betreffend bestuur van de eredienst`
5. Verify that the dropdown now shows kbo numbers for the orgs
