### PR TITLE
Update documentation feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ submission can be enriched with data from the triple store.
 Add the following snippet to your `docker-compose.yml`:
 
 ```yml
-enrich-submission:.
   image: lblod/enrich-submission-service
   environment:
     ACTIVE_FORM_FILE: "share://semantic-forms/<your-active-form-definitions>.ttl"
@@ -19,15 +18,15 @@ enrich-submission:.
     - ./data/files/submissions:/share/submissions
 ```
 
-The `ACTIVE_FORM_FILE` environment variable must contain a URI off the format
+The `ACTIVE_FORM_FILE` environment variable must contain a URI of the format
 `share://semantic-forms/<your-active-form-definitions>.ttl`. This links to the
 Turtle file that contains the currently active form definitions.
 
-The volume mounted in `/share/semantic-forms` must contain all the Turtle files
+The volume mounted on `/share/semantic-forms` must contain all the Turtle files
 containing the current and deprecated form definitions. We recommend adding a
 timestamp to the Turtle files to differentiate over time.
 
-The volume mounted in `/share/submissions` must contain the Turtle files
+The volume mounted on `/share/submissions` must contain the Turtle files
 containing the data harvested from the published documents. The resulting
 Turtle files to fill in the forms will also be written to this folder.
 
@@ -72,7 +71,7 @@ export default [
 POST /delta
 ```
 
-Triggers the enrichment for harvested publications. I.e. associates the current
+Triggers the enrichment for harvested publications. It associates the current
 active form to the submission and prepares a meta TTL containing data from the
 store that is required to fill in and validate the form.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ export default [
 
 ## Reference
 
+### Configuration
+
+Some environment variables can be used to tweak this service. The following
+list can be used in the `environment` mapping of the service definition:
+
+* `GRAPH_TEMPLATE`: <em>(optional, default:
+  `http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker`)
+   </em> this URI represents the graph URI where the form files are stored and
+   retrieved in most cases. There has to be a `~ORGANIZATION_ID~` in it,
+   because that is replaced with the organisation UUID of the requester.
+*  `OVERRULE_ORG_CHECK_ON_READ`: <em>(optional, default: "false")</em> in
+   certain read applications, the graphs containing the data for the
+   submissions isn't always structured per organisation. This service only
+   allows data from graphs containing the organisation UUID unless this boolean
+   is set to "true", ommitting the strict filter.
+
 ### API
 
 #### Delta handling (automatic submissions)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # enrich-submission-service
+
 Microservice to enrich a submission harvested from a published document. A submission can be enriched with data from the triple store.
 
 ## Getting started
+
 ### Add the service to a stack
+
 Add the following snippet to your `docker-compose.yml`:
 
 ```yml
@@ -14,6 +17,7 @@ enrich-submission:.
     - ./config/semantic-forms:/share/semantic-forms
     - ./data/files/submissions:/share/submissions
 ```
+
 The `ACTIVE_FORM_FILE` environment variable must contain a URI off the format `share://semantic-forms/<your-active-form-definitions>.ttl`. This links to the Turtle file that contains the currently active form definitions.
 
 The volume mounted in `/share/semantic-forms` must contain all the Turtle files containing the current and deprecated form definitions. We recommend adding a timestamp to the Turtle files to differentiate over time.
@@ -49,31 +53,39 @@ export default [
 ```
 
 ## Reference
+
 ### API
+
 #### Delta handling (automatic submissions)
+
 ```
 POST /delta
 ```
+
 Triggers the enrichment for harvested publications. I.e. associates the current active form to the submission and prepares a meta TTL containing data from the store that is required to fill in and validate the form.
 
 #### Retrieval of submission document to render as a form
+
 ```
 GET /submission-documents/:uuid
 ```
+
 Get the data for a submission form based on the submitted document uuid.
 
 Returns an object with
+
 * source: TTL of the harvested data (in case of a concept submission) or sent data (in case of a sent submission)
 * additions: TTL containing manually added triples
 * removals: TTL containing manually removed triples
 * meta: TTL containing additional data to fill in and validate the forms. The TTL is a snapshot of the current meta data at the moment of the request. It may change over time as long as the submission is in concept state.
 * form: TTL containing the description of the forms. The form is the current active form at the moment of the request. It may change over time as long as the submission is in concept state.
 
-
 #### Manual deletion of submission document
+
 ```
 DELETE /submission-documents/:uuid
 ```
+
 Deletes the data and related files on disk for a submission form based on the submitted document uuid.
 
 ### Model
@@ -99,24 +111,33 @@ Once the enrichment process starts, the status of the automatic submission task 
 On successful completion, the status of the automatic submission task is updated to http://redpencil.data.gift/id/concept/JobStatus/success. The resultsContainer is then linked to the inputContainer of the task, because no file has been created or modified, only triples in the database.
 
 On failure, the status is updated to http://redpencil.data.gift/id/concept/JobStatus/failed. If possible, an error is written to the database and the error is linked to this failed task.
+
 ___
+
 #### Submitted document
+
 ##### Class
+
 `foaf:Document` (and `ext:SubmissionDocument`)
 
 ##### Properties
+
 | Name   | Predicate    | Range                | Definition                                                                                 |
 |--------|--------------|----------------------|--------------------------------------------------------------------------------------------|
 | source | `dct:source` | `nfo:FileDataObject` | TTL files containing data about the submitted document. The TTL files have different types |
 
 ___
+
 #### Turtle file
+
 TTL file containing triples used to fill in a form.
 
 ##### Class
+
 `nfo:FileDataObject`
 
 ##### Properties
+
 | Name | Predicate    | Range                | Definition                                                                                                                                   |
 |------|--------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | type | `dct:type` | `nfo:FileDataObject` | Type of the TTL file (additions, removals, meta, form, current filled in form data) |
@@ -124,6 +145,7 @@ TTL file containing triples used to fill in a form.
 Additional properties are specified in the model of the [file service](https://github.com/mu-semtech/file-service#resources).
 
 Possible values of the file type are:
+
 * http://data.lblod.gift/concepts/form-file-type: file containing the semantic form description
 * http://data.lblod.gift/concepts/form-data-file-type: file containing the current filled in data of the form
 * http://data.lblod.gift/concepts/additions-file-type: file containing manually added triples
@@ -131,9 +153,12 @@ Possible values of the file type are:
 * http://data.lblod.gift/concepts/meta-file-type: file containing additonal data from the triple store to fill in and validate the form
 
 ## Related services
+
 The following services are also involved in the automatic processing of a submission:
+
 * [automatic-submission-service](https://github.com/lblod/automatic-submission-service)
 * [download-url-service](https://github.com/lblod/download-url-service)
 * [import-submission-service](https://github.com/lblod/import-submission-service)
 * [validate-submission-service](https://github.com/lblod/validate-submission-service)
 * [toezicht-flattened-form-data-generator](https://github.com/lblod/toezicht-flattened-form-data-generator)
+

--- a/README.md
+++ b/README.md
@@ -122,9 +122,7 @@ automatic submission job.
 The model is specified in the [README of the
 job-controller-service](https://github.com/lblod/job-controller-service#task).
 
-___
-
-#### Automatic submission task statuses
+##### Statuses
 
 Once the enrichment process starts, the status of the automatic submission task
 is updated to `http://redpencil.data.gift/id/concept/JobStatus/busy`.
@@ -138,8 +136,6 @@ On failure, the status is updated to
 `http://redpencil.data.gift/id/concept/JobStatus/failed`. If possible, an error
 is written to the database and the error is linked to this failed task.
 
-___
-
 #### Submitted document
 
 ##### Class
@@ -151,8 +147,6 @@ ___
 | Name   | Predicate    | Range                | Definition                                                                                 |
 |--------|--------------|----------------------|--------------------------------------------------------------------------------------------|
 | source | `dct:source` | `nfo:FileDataObject` | TTL files containing data about the submitted document. The TTL files have different types |
-
-___
 
 #### Turtle file
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ DELETE /submission-documents/:uuid
 ```
 
 Deletes the data and related files on disk for a submission form based on the
-submitted document uuid.
-
+submitted document uuid. This is only possible if the document is not in sent
+status.
+ 
 ### Model
 
 #### Automatic submission task

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # enrich-submission-service
 
-Microservice to enrich a submission harvested from a published document. A submission can be enriched with data from the triple store.
+Microservice to enrich a submission harvested from a published document. A
+submission can be enriched with data from the triple store.
 
 ## Getting started
 
@@ -18,13 +19,22 @@ enrich-submission:.
     - ./data/files/submissions:/share/submissions
 ```
 
-The `ACTIVE_FORM_FILE` environment variable must contain a URI off the format `share://semantic-forms/<your-active-form-definitions>.ttl`. This links to the Turtle file that contains the currently active form definitions.
+The `ACTIVE_FORM_FILE` environment variable must contain a URI off the format
+`share://semantic-forms/<your-active-form-definitions>.ttl`. This links to the
+Turtle file that contains the currently active form definitions.
 
-The volume mounted in `/share/semantic-forms` must contain all the Turtle files containing the current and deprecated form definitions. We recommend adding a timestamp to the Turtle files to differentiate over time.
+The volume mounted in `/share/semantic-forms` must contain all the Turtle files
+containing the current and deprecated form definitions. We recommend adding a
+timestamp to the Turtle files to differentiate over time.
 
-The volume mounted in `/share/submissions` must contain the Turtle files containing the data harvested from the published documents. The resulting Turtle files to fill in the forms will also be written to this folder.
+The volume mounted in `/share/submissions` must contain the Turtle files
+containing the data harvested from the published documents. The resulting
+Turtle files to fill in the forms will also be written to this folder.
 
-Configure the delta-notification service to send notifications on the `/delta` endpoint when a publication is harvested, i.e. when a harvested TTL is inserted. Add the following snippet in the delta rules configuration of your project:
+Configure the delta-notification service to send notifications on the `/delta`
+endpoint when a publication is harvested, i.e. when a harvested TTL is
+inserted. Add the following snippet in the delta rules configuration of your
+project:
 
 ```javascript
 export default [
@@ -62,7 +72,9 @@ export default [
 POST /delta
 ```
 
-Triggers the enrichment for harvested publications. I.e. associates the current active form to the submission and prepares a meta TTL containing data from the store that is required to fill in and validate the form.
+Triggers the enrichment for harvested publications. I.e. associates the current
+active form to the submission and prepares a meta TTL containing data from the
+store that is required to fill in and validate the form.
 
 #### Retrieval of submission document to render as a form
 
@@ -74,11 +86,16 @@ Get the data for a submission form based on the submitted document uuid.
 
 Returns an object with
 
-* source: TTL of the harvested data (in case of a concept submission) or sent data (in case of a sent submission)
+* source: TTL of the harvested data (in case of a concept submission) or sent
+  data (in case of a sent submission)
 * additions: TTL containing manually added triples
 * removals: TTL containing manually removed triples
-* meta: TTL containing additional data to fill in and validate the forms. The TTL is a snapshot of the current meta data at the moment of the request. It may change over time as long as the submission is in concept state.
-* form: TTL containing the description of the forms. The form is the current active form at the moment of the request. It may change over time as long as the submission is in concept state.
+* meta: TTL containing additional data to fill in and validate the forms. The
+  TTL is a snapshot of the current meta data at the moment of the request. It
+  may change over time as long as the submission is in concept state.
+* form: TTL containing the description of the forms. The form is the current
+  active form at the moment of the request. It may change over time as long as
+  the submission is in concept state.
 
 #### Manual deletion of submission document
 
@@ -86,13 +103,15 @@ Returns an object with
 DELETE /submission-documents/:uuid
 ```
 
-Deletes the data and related files on disk for a submission form based on the submitted document uuid.
+Deletes the data and related files on disk for a submission form based on the
+submitted document uuid.
 
 ### Model
 
 #### Automatic submission task
 
-A resource describing the status and operation of the subtask of processing an automatic submission job.
+A resource describing the status and operation of the subtask of processing an
+automatic submission job.
 
 ##### Class
 
@@ -100,17 +119,24 @@ A resource describing the status and operation of the subtask of processing an a
 
 ##### Properties
 
-The model is specified in the [README of the job-controller-service](https://github.com/lblod/job-controller-service#task).
+The model is specified in the [README of the
+job-controller-service](https://github.com/lblod/job-controller-service#task).
 
 ___
 
 #### Automatic submission task statuses
 
-Once the enrichment process starts, the status of the automatic submission task is updated to http://redpencil.data.gift/id/concept/JobStatus/busy.
+Once the enrichment process starts, the status of the automatic submission task
+is updated to http://redpencil.data.gift/id/concept/JobStatus/busy.
 
-On successful completion, the status of the automatic submission task is updated to http://redpencil.data.gift/id/concept/JobStatus/success. The resultsContainer is then linked to the inputContainer of the task, because no file has been created or modified, only triples in the database.
+On successful completion, the status of the automatic submission task is
+updated to http://redpencil.data.gift/id/concept/JobStatus/success. The
+resultsContainer is then linked to the inputContainer of the task, because no
+file has been created or modified, only triples in the database.
 
-On failure, the status is updated to http://redpencil.data.gift/id/concept/JobStatus/failed. If possible, an error is written to the database and the error is linked to this failed task.
+On failure, the status is updated to
+http://redpencil.data.gift/id/concept/JobStatus/failed. If possible, an error
+is written to the database and the error is linked to this failed task.
 
 ___
 
@@ -138,23 +164,30 @@ TTL file containing triples used to fill in a form.
 
 ##### Properties
 
-| Name | Predicate    | Range                | Definition                                                                                                                                   |
-|------|--------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| Name | Predicate  | Range                | Definition                                                                          |
+|------|------------|----------------------|-------------------------------------------------------------------------------------|
 | type | `dct:type` | `nfo:FileDataObject` | Type of the TTL file (additions, removals, meta, form, current filled in form data) |
 
-Additional properties are specified in the model of the [file service](https://github.com/mu-semtech/file-service#resources).
+Additional properties are specified in the model of the [file
+service](https://github.com/mu-semtech/file-service#resources).
 
 Possible values of the file type are:
 
-* http://data.lblod.gift/concepts/form-file-type: file containing the semantic form description
-* http://data.lblod.gift/concepts/form-data-file-type: file containing the current filled in data of the form
-* http://data.lblod.gift/concepts/additions-file-type: file containing manually added triples
-* http://data.lblod.gift/concepts/removals-file-type: file containing manually removed triples
-* http://data.lblod.gift/concepts/meta-file-type: file containing additonal data from the triple store to fill in and validate the form
+* http://data.lblod.gift/concepts/form-file-type: file containing the semantic
+  form description
+* http://data.lblod.gift/concepts/form-data-file-type: file containing the
+  current filled in data of the form
+* http://data.lblod.gift/concepts/additions-file-type: file containing manually
+  added triples
+* http://data.lblod.gift/concepts/removals-file-type: file containing manually
+  removed triples
+* http://data.lblod.gift/concepts/meta-file-type: file containing additonal
+  data from the triple store to fill in and validate the form
 
 ## Related services
 
-The following services are also involved in the automatic processing of a submission:
+The following services are also involved in the automatic processing of a
+submission:
 
 * [automatic-submission-service](https://github.com/lblod/automatic-submission-service)
 * [download-url-service](https://github.com/lblod/download-url-service)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# enrich-submission-service
+# `enrich-submission-service`
 
 Microservice to enrich a submission harvested from a published document. A
 submission can be enriched with data from the triple store.
@@ -10,7 +10,8 @@ submission can be enriched with data from the triple store.
 Add the following snippet to your `docker-compose.yml`:
 
 ```yml
-  image: lblod/enrich-submission-service
+enrich-submission:
+  image: lblod/enrich-submission-service:X.Y.Z
   environment:
     ACTIVE_FORM_FILE: "share://semantic-forms/<your-active-form-definitions>.ttl"
   volumes:
@@ -85,14 +86,14 @@ Get the data for a submission form based on the submitted document uuid.
 
 Returns an object with
 
-* source: TTL of the harvested data (in case of a concept submission) or sent
+* `source`: TTL of the harvested data (in case of a concept submission) or sent
   data (in case of a sent submission)
-* additions: TTL containing manually added triples
-* removals: TTL containing manually removed triples
-* meta: TTL containing additional data to fill in and validate the forms. The
+* `additions`: TTL containing manually added triples
+* `removals`: TTL containing manually removed triples
+* `meta`: TTL containing additional data to fill in and validate the forms. The
   TTL is a snapshot of the current meta data at the moment of the request. It
   may change over time as long as the submission is in concept state.
-* form: TTL containing the description of the forms. The form is the current
+* `form`: TTL containing the description of the forms. The form is the current
   active form at the moment of the request. It may change over time as long as
   the submission is in concept state.
 
@@ -126,15 +127,15 @@ ___
 #### Automatic submission task statuses
 
 Once the enrichment process starts, the status of the automatic submission task
-is updated to http://redpencil.data.gift/id/concept/JobStatus/busy.
+is updated to `http://redpencil.data.gift/id/concept/JobStatus/busy`.
 
 On successful completion, the status of the automatic submission task is
-updated to http://redpencil.data.gift/id/concept/JobStatus/success. The
-resultsContainer is then linked to the inputContainer of the task, because no
-file has been created or modified, only triples in the database.
+updated to `http://redpencil.data.gift/id/concept/JobStatus/success`. The
+`resultsContainer` is then linked to the `inputContainer` of the task, because
+no file has been created or modified, only triples in the database.
 
 On failure, the status is updated to
-http://redpencil.data.gift/id/concept/JobStatus/failed. If possible, an error
+`http://redpencil.data.gift/id/concept/JobStatus/failed`. If possible, an error
 is written to the database and the error is linked to this failed task.
 
 ___
@@ -172,15 +173,15 @@ service](https://github.com/mu-semtech/file-service#resources).
 
 Possible values of the file type are:
 
-* http://data.lblod.gift/concepts/form-file-type: file containing the semantic
-  form description
-* http://data.lblod.gift/concepts/form-data-file-type: file containing the
+* `http://data.lblod.gift/concepts/form-file-type`: file containing the
+  semantic form description
+* `http://data.lblod.gift/concepts/form-data-file-type`: file containing the
   current filled in data of the form
-* http://data.lblod.gift/concepts/additions-file-type: file containing manually
-  added triples
-* http://data.lblod.gift/concepts/removals-file-type: file containing manually
-  removed triples
-* http://data.lblod.gift/concepts/meta-file-type: file containing additonal
+* `http://data.lblod.gift/concepts/additions-file-type`: file containing
+  manually added triples
+* `http://data.lblod.gift/concepts/removals-file-type`: file containing
+  manually removed triples
+* `http://data.lblod.gift/concepts/meta-file-type`: file containing additonal
   data from the triple store to fill in and validate the form
 
 ## Related services


### PR DESCRIPTION
**[DL-5157]**

Improvements on the documentation. Some spelling fixes, whitespace management and overall formatting, but most importantly, the addition of a paragraph on the environment variables. For this, see commit d52c0d4ee0ae4ca0d71bfeeaa0b46b850edd125c (all except for this commit are mostly formatting related).